### PR TITLE
Style fixes

### DIFF
--- a/front-end/src/components/Modal/Modal.less
+++ b/front-end/src/components/Modal/Modal.less
@@ -4,7 +4,7 @@ dialog.modal {
   border-radius: 5px;
   max-width: 625px;
   min-width: 475px;
-  padding: 30px;
+  padding: 2rem;
   border: none;
   border-top: 5px solid @green;
   outline: none;

--- a/front-end/src/pages/Account/AccountPage.tsx
+++ b/front-end/src/pages/Account/AccountPage.tsx
@@ -39,7 +39,7 @@ export default function AccountPage(): ReactElement {
       <div className='row row__content row__summary'>
         <AccountOverview accountData={accountData} eventData={eventData} />
       </div>
-      <div className='row row__action u-mt0 u-mb0'>
+      <div className='row row__right u-mt0 u-mb0'>
         <AccountDownloader
           rows={rows}
           fields={fields}


### PR DESCRIPTION
Remove unnecessary scrollbars on modals and right align account download button.

## Changes

- Fix unit mismatch in modal spacing to prevent unnecessary scrollbars 
- Update row class for account download button so it's right aligned

## Testing

1. Check out branch
2. In System Settings, select `Always` under `Show scroll bars`
3. Navigate to [landing page](http://localhost:3000/) and note that no scroll bars appear on warning modal (If modal is not showing up, delete the warning cookie on the Application tab in dev tools)
4. Navigate to an account page and verify that download button is right aligned

## Screenshots

| | Before | After |
| -- | -- | -- |
| Modal |<img width="858" height="466" alt="Screenshot 2025-08-21 at 2 58 42 PM" src="https://github.com/user-attachments/assets/ea1b1516-a7cc-46ae-9e1b-866841f7ce53" /> |<img width="839" height="472" alt="Screenshot 2025-08-21 at 2 53 15 PM" src="https://github.com/user-attachments/assets/66b74e5e-a2a5-4809-a63b-f2143190d38e" /> |
| Account&nbsp;button | <img width="997" height="161" alt="Screenshot 2025-08-21 at 2 54 27 PM" src="https://github.com/user-attachments/assets/659f3088-3eea-43ee-8ae2-c5429fff7e0c" />  | <img width="1005" height="164" alt="Screenshot 2025-08-21 at 2 54 10 PM" src="https://github.com/user-attachments/assets/62f3a652-a978-420a-9da0-04c6e1d16fce" /> |




