### PR TITLE
Move documentation to a wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@ CFPB’s Metro2 Evaluator Tool (M2) evaluates Metro2 data for inaccuracies which
 
 The application has a Django back-end which connects to a Postgres database. The back end fetches Metro2 data files from an S3 bucket, parses the relevant data into the database, and runs evaluators on the data. The back end also handles authorization for users and provides API endpoints to expose the evaluated data to the front end. The front-end provides a React-based interface for authenticated and authorized users and allows them to interact with the data.
 
+For more information about how the Metro2 application works, as well as features and design decisions, please see the [Metro2 Wiki](https://github.com/cfpb/Metro2/wiki).
+
 ![](Screenshot.png)
 
 ## Sections
 - [Running the project locally](#running-the-project-locally)
     - [Running in docker-compose](#running-in-docker-compose)
 - [Management commands](#running-management-commands)
-- [Handling evaluator metadata](#handling-evaluator-metadata)
 - [Testing](#testing)
   - [Running tests and checking coverage](#running-tests-and-checking-coverage)
 
@@ -39,34 +40,6 @@ Both the **Django** and **Front-end** code bases can be run locally. See the REA
 Django management commands are used for several essential actions in the Metro2 application, including parsing new data, running evaluators, and importing evaluator metadata from CSV.
 To see the full list of available management commands, run `python manage.py help` from the django directory.
 In local environments, use the command line to run these commands.
-
-# Handling evaluator metadata
-Each evaluator has several metadata fields associated with it, such as name, short description, long description, fields used, rationale, and more.
-We seed the database with initial metadata about each evaluator, then allow users to modify some of the fields.
-
-## Evaluator CSV format
-When importing and exporting evaluator metadata, we use a CSV with the following columns:
-`id`,`category`,`description`,`long_description`,`fields_used`,`fields_display`,`rationale`,`potential_harm`,`alternate_explanation`,`crrg_reference`
-
-The `id` column is what we use to connect the evaluator metadata to the evaluator function, which is defined in code.
-This means that the `id` column needs to exactly match the name of the function in the code.
-If the names don't match, any evaluator results won't be correctly associated with the evaluator in the system.
-
-## Importing metadata
-Do this when deploying the project to a new environment to create evaluator metadata records in the database.
-
-How to import the evaluator metadata into the system:
-1. Create a CSV of all known evaluator metadata using the format described above.
-2. Save the CSV to this repo using the following filename: `cfpb_evaluators/eval_metadata.csv`.
-3. Import the metadata by running the following Django management command in the environment where the metadata should be imported: `python manage.py import_evaluator_metadata`.
-    - This command will update any existing records with the new metadata and create any that don't already exist. It won't delete existing records that are missing from the csv.
-
-## Exporting metadata
-Do this when users have made manual updates to the evaluator metadata and you want to propagate those updates to another environment.
-
-How to export the evaluator metadata:
-1. Visit the `/all-evaluator-metadata` endpoint for the environment in the browser.
-    - This will download a CSV of all evaluator metadata in the system, which you can import into any Metro2 environment.
 
 
 # Testing

--- a/django/README.md
+++ b/django/README.md
@@ -12,7 +12,7 @@ The Metro2 Django app parses Metro2 data, runs evaluators, manages user access, 
 ## How to run in docker-compose (recommended)
 If you have docker-compose installed, this will be the simplest strategy.
 If not, you can use the instructions under [[How to run locally]] below.
-Running in docker-compose uses the Django settings specified in `django_application/settings/docker-compose.py` and connects to a PostgreSQL database that is managed by docker-compose.
+Running in docker-compose uses the Django settings specified in `django_application/settings/docker_compose.py` and connects to a PostgreSQL database that is managed by docker-compose.
 
 Running the project:
 1. From the Metro2 project root, run `docker compose build` and `docker compose up` to get the app running.


### PR DESCRIPTION
## Changes

- Point to the wiki from the main README
- Move evaluator docs to the wiki
- Correct minor typo in django/README