### PR TITLE
Download Modal Cypress Tests

### DIFF
--- a/front-end/cypress/component/DownloadModal.cy.tsx
+++ b/front-end/cypress/component/DownloadModal.cy.tsx
@@ -11,15 +11,16 @@ describe('DownloadModal.cy.tsx', () => {
   })
   
   it('PII checkbox unchecked on page load', () => {
-    cy.get('.modal')
-    cy.findByTestId('pii-checkbox')
-    cy.get('[type="checkbox"]').should('not.be.checked')
+    cy.get('.modal').within( () => {  
+       cy.findByTestId('pii-checkbox').should('not.be.checked')  
+    })  
   })
 
   it('Download button disabled on page load', () => {
-    cy.get('.modal')
-    cy.findByTestId('csv-download-button')
-    .should('be.disabled')
+    cy.get('.modal').within( () => {
+       cy.findByTestId('csv-download-button')
+        .should('be.disabled')
+    })
   })
 
   it('Download button is enable/disabled with PII checkbox value', () => {
@@ -27,8 +28,7 @@ describe('DownloadModal.cy.tsx', () => {
     cy.get('label').click()
     cy.findByTestId('csv-download-button')
     .should('be.enabled')
-    cy.findByTestId('pii-checkbox')
-    cy.get('label').click()
+    cy.get('label').contains('PII').click()
     cy.findByTestId('csv-download-button')
     .should('be.disabled')
   })

--- a/front-end/cypress/component/DownloadModal.cy.tsx
+++ b/front-end/cypress/component/DownloadModal.cy.tsx
@@ -1,0 +1,35 @@
+import DownloadModal from '../../src/components/Modal/DownloadModal'
+
+describe('DownloadModal.cy.tsx', () => {
+  beforeEach(() => {
+    cy.mount(<DownloadModal open={true}/>)
+  });
+
+  it('Displays download modal', () => {
+    cy.get('.modal')
+    .should('be.visible')
+  })
+  
+  it('PII checkbox unchecked on page load', () => {
+    cy.get('.modal')
+    cy.findByTestId('pii-checkbox')
+    cy.get('[type="checkbox"]').should('not.be.checked')
+  })
+
+  it('Download button disabled on page load', () => {
+    cy.get('.modal')
+    cy.findByTestId('csv-download-button')
+    .should('be.disabled')
+  })
+
+  it('Download button is enable/disabled with PII checkbox value', () => {
+    cy.findByTestId('pii-checkbox')
+    cy.get('label').click()
+    cy.findByTestId('csv-download-button')
+    .should('be.enabled')
+    cy.findByTestId('pii-checkbox')
+    cy.get('label').click()
+    cy.findByTestId('csv-download-button')
+    .should('be.disabled')
+  })
+})

--- a/front-end/src/components/Modal/DownloadModal.tsx
+++ b/front-end/src/components/Modal/DownloadModal.tsx
@@ -58,6 +58,7 @@ export default function DownloadModal({
               id='confirmPII'
               isLarge
               checked={isChecked}
+              data-testid='pii-checkbox'
               label='I confirm that I am knowingly downloading PII or CI and understand that I am responsible for safeguarding this data.'
               onChange={onChange}
             />


### PR DESCRIPTION
As a step in expanding cypress test coverage for components, as outlined in issue [931](https://github.cfpb.gov/Design-Development/Internal-Products/issues/931), this PR creates a cypress test file for the download modal component.

## Changes
- Adds download modal cypress test file

## Testing instructions
1. Check out branch
2. Run `yarn` for cypress dependencies
3. Run `yarn cypress open`, open components testing, and open DownloadModal
4. Verify all tests pass