### PR TITLE
Add fallback for results count on sample view

### DIFF
--- a/front-end/src/pages/Evaluator/results/EvaluatorResults.tsx
+++ b/front-end/src/pages/Evaluator/results/EvaluatorResults.tsx
@@ -52,7 +52,8 @@ export default function EvaluatorResults({
   )
 
   const totalHits = evaluatorMetadata.hits
-  const currentHits = data?.count ?? 0
+  const currentHits = view === 'sample' ? (data?.hits.length ?? 0) : (data?.count ?? 0)
+ 
   const pageCount = getPageCount(currentHits, page_size)
 
   // TODO: consider refining this to handle 404s for invalid page
@@ -75,7 +76,7 @@ export default function EvaluatorResults({
       <div className='loader_wrapper'>
         {isFetching ? <Loader message='Your data is loading' /> : null}
         <div className='evaluator-hits-row'>
-          <div className='row row__content u-mt0 tab-panel'>
+          <div className='row row__content u-mt0'>
             <div className='tab-panel'>
               <div className={`results-container results-container__${view}`}>
                 <div className='row row__action '>


### PR DESCRIPTION
Addresses issue 956.

On production, the results message on the sample view says "Showing 0 results" despite the fact that sample results have been received from the API and are displayed in the table. This appears to be occuring because no `count` value is returned on evaluator hits requests with the sample view param, and that triggers the `no results` branch in the results message logic. 

This PR updates the evaluator results view code so that the length of the hits array is passed to the results message component when the count value is missing in the data returned from the api on the sample view.


## Changes

- Update how `currentHitsCount` value is determined

## Testing

1. Check out branch
2. Navigate to [event results page](http://localhost:3000/events/1) and click on links for an evaluator with less than 20 results and one with more than 20 results. Verify that the results messaging looks correct for the sample view, all results view, and filtered views on each of the pages.
3. Run `yarn validate` and verify that everything passes

