### PR TITLE
Filter accessibility fix

### DIFF
--- a/front-end/cypress/component/Accordion.cy.tsx
+++ b/front-end/cypress/component/Accordion.cy.tsx
@@ -4,68 +4,69 @@ import '../fixtures/event_1.json'
 
 describe('Accordion.cy.tsx', () => {
   beforeEach(() => {
-      // Code to run before each 'it'in describe block
-      cy.mount(<Accordion header='Criteria evaluated'>
-        <div className="long-description">
+    // Code to run before each 'it'in describe block
+    cy.mount(
+      <Accordion header='Criteria evaluated'>
+        <div className='long-description'>
           <h4>Subheading</h4>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-          </div>
-      </Accordion>)
+        </div>
+      </Accordion>
+    )
   })
-      
+
   it('displays accordion', () => {
     cy.findByTestId('accordion')
-    .find('button')
-    .contains('Criteria evaluated')
-    .and('be.visible')
+      .find('button')
+      .contains('Criteria evaluated')
+      .and('be.visible')
   })
 
   it('accordion has a border by default', () => {
     cy.findByTestId('accordion')
-    .should('have.class', 'o-expandable__border')
-    .and('have.css', 'border')
+      .should('have.class', 'o-expandable__border')
+      .and('have.css', 'border')
   })
 
   it('accordion is closed on load', () => {
     cy.findByTestId('accordion')
-    .find('button') 
-    .should('have.text', 'Criteria evaluated')
-    cy.findByTestId('accordion-inner')
-    .should('not.be.visible')
+      .find('button')
+      .should('have.text', 'Criteria evaluated')
+    cy.findByTestId('accordion-content').should('not.be.visible')
   })
 
   it('accordion expands', () => {
     cy.findByTestId('accordion')
-    .find('button') 
-    .should('have.text', 'Criteria evaluated').click()
-    cy.findByTestId('expandable-content')
-    cy.findByTestId('accordion-inner')
-    .should('be.visible')
+      .find('button')
+      .should('have.text', 'Criteria evaluated')
+      .click()
+    cy.findByTestId('accordion-content').should('be.visible')
   })
 
   it('load accordion child content', () => {
-    cy.findByTestId('accordion')
-    .find('button').click()
-    cy.findByTestId('accordion-inner')
-    .should('be.visible')
-    .get('div.long-description').within(() => {
-      cy.get('h4').should('exist');
-      cy.get('p').should('exist')
-    })
+    cy.findByTestId('accordion').find('button').click()
+    cy.findByTestId('accordion-content')
+      .should('be.visible')
+      .get('div.long-description')
+      .within(() => {
+        cy.get('h4').should('exist')
+        cy.get('p').should('exist')
+      })
   })
 
   it('down arrow displayed on load', () => {
-     cy.findByTestId('accordion')
-    .find('button')
-    .find('svg')
-    .should('have.attr', 'alt', 'down')
+    cy.findByTestId('accordion')
+      .find('button')
+      .find('svg')
+      .should('have.attr', 'alt', 'down')
   })
 
   it('down arrow switches to up arrow on click', () => {
     cy.findByTestId('accordion')
-    .find('button')
-    .find('svg').click()
-    .get('svg.cf-icon-svg--up')
-    .should('have.attr', 'alt', 'up')
+      .find('button')
+      .find('svg')
+      .click()
+      .get('svg.cf-icon-svg--up')
+      .should('have.attr', 'alt', 'up')
   })
 })

--- a/front-end/src/components/Accordion/Accordion.less
+++ b/front-end/src/components/Accordion/Accordion.less
@@ -5,39 +5,35 @@
   // no background expandable variant
   background-color: inherit !important;
   border-width: 1px 0 !important;
+  overflow: hidden;
 
-  &_content {
+  &_wrapper {
     display: grid;
     grid-template-rows: 0fr;
+    // overflow: hidden;
     transition: grid-template-rows 0.3s ease-in-out;
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
 
     &::before {
       display: none !important;
     }
   }
 
-  &_inner {
-    overflow: hidden;
-
-    &::before {
-      content: '';
-      display: block;
-      border-top: 1px solid gray;
-      padding-bottom: unit((@grid_gutter-width / 2 / @base-font-size-px), em);
-    }
-
-    &::after {
-      padding-bottom: unit((@grid_gutter-width / 2 / @base-font-size-px), em);
-      display: block;
-      content: '';
-    }
+  &__open > &_wrapper {
+    grid-template-rows: 1fr;
   }
 
-  &__open > &_content {
-    grid-template-rows: 1fr;
-    padding-bottom: unit((@grid_gutter-width / 2 / @base-font-size-px), em);
+  &_inner {
+    // min-height: 0;
+    overflow: hidden;
+  }
+
+  &_content {
+    visibility: hidden;
+    transition: visibility 0.3s ease-in-out;
+  }
+
+  &__open > &_wrapper > &_inner > &_content {
+    visibility: visible;
   }
 
   &_target {

--- a/front-end/src/components/Accordion/Accordion.tsx
+++ b/front-end/src/components/Accordion/Accordion.tsx
@@ -76,8 +76,13 @@ export default function Accordion({
           </button>
         </div>
       )}
-      <div data-testid='expandable-content' className='o-expandable_content'>
-        <div data-testid='accordion-inner' className='o-expandable_inner'>{children}</div>
+
+      <div data-testid='accordion-wrapper' className='o-expandable_wrapper'>
+        <div data-testid='accordion-inner' className='o-expandable_inner'>
+          <div data-testid='accordion-content' className='o-expandable_content'>
+            {children}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/front-end/src/components/Filters/NestedCheckboxGroup/NestedCheckboxGroup.less
+++ b/front-end/src/components/Filters/NestedCheckboxGroup/NestedCheckboxGroup.less
@@ -8,9 +8,7 @@
     &_content {
       padding-left: 0;
       padding-right: 0;
-    }
 
-    &_inner {
       > .nested {
         margin-left: 1.75rem;
       }
@@ -26,6 +24,12 @@
       .m-form-field__checkbox + .o-expandable {
         margin-top: 0.75rem;
       }
+    }
+  }
+
+  &:not(.o-expandable__open) {
+    .o-expandable_content {
+      visibility: hidden !important;
     }
   }
 }


### PR DESCRIPTION
Addresses 957. 

Removes form elements in closed expandables from tab order. 

## Changes

- Update expandable code to set visibility: hidden on expandable contents when closed so form elements in closed expandables are excluded from tab order
- Update accordion tests to reflect changes

## Testing

1. Check out branch
2. Navigate to an evaluator page and select the all results view. Test keyboard accessibility in filters:
    a. Tab through closed filters and verify that focus goes from one accordion header to another and doesn't include the form elements inside the expandable
    b. Open account status expandable and one of its child accordions. Verify that the visible form elements are included in the tab order
    c. Close the account status expandable without closing its children. Verify that the children are skipped in tab order.
3. Run `yarn validate` and verify that everything passes