### PR TITLE
Upgrade Django to remediate CVE

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,7 +1,7 @@
 APScheduler==3.11.0
 asgiref==3.8.1
 coverage==7.8.0
-Django==4.2.22
+Django==4.2.25
 psycopg2-binary==2.9.10
 ruff==0.11.4
 boto3==1.37.29


### PR DESCRIPTION
## Changes

- Upgrade the Django version from 4.2.22 to 4.2.25 to remediate a CVE.

## Testing

1. `python manage.py test`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated