### PR TITLE
Fix event download

### DIFF
--- a/front-end/.gitignore
+++ b/front-end/.gitignore
@@ -8,6 +8,8 @@ coverage
 .nyc_output
 .stylelintcache
 cypress/videos
+cypress/downloads
+cypress/screenshots
 .yarn/*
 !.yarn/cache
 !.yarn/releases

--- a/front-end/cypress/e2e/page_Evaluator_Downloads.cy.ts
+++ b/front-end/cypress/e2e/page_Evaluator_Downloads.cy.ts
@@ -38,5 +38,14 @@ describe('Evaluator page', () => {
       modal.openModal('Save results')
       modal.verifyPrivacyCheckboxRequired()
     })
+
+    it('Should download sample evaluator results when download button clicked', () => {
+      modal.openModal('Save results')
+      modal.checkPIICheckbox()
+      modal.getSaveButton().click()
+      cy.readFile(
+        'cypress/downloads/Browser-testing-event_Test-Eval-1_sample.csv'
+      ).should('exist')
+    })
   })
 })

--- a/front-end/cypress/e2e/page_Event.cy.ts
+++ b/front-end/cypress/e2e/page_Event.cy.ts
@@ -4,12 +4,14 @@ import type Event from '@src/types/Event'
 import data from '../fixtures/event_1.json'
 import { Metro2Page } from '../helpers/pageHelper'
 import { Metro2Table } from '../helpers/tableHelpers'
-
 const eventData = data as Event
 
 // Instantiate helpers
 const table = new Metro2Table()
 const eventPage = new Metro2Page()
+
+import { Metro2Modal } from '../helpers/modalHelpers'
+const modal = new Metro2Modal()
 
 describe('Event page loader', () => {
   it('Should show a loading view while event data fetched', () => {
@@ -85,7 +87,29 @@ describe('Event file download', () => {
     cy.intercept('GET', 'api/events/1', { fixture: 'event_1' }).as('getEvent')
     cy.visit('/events/1')
   })
-  it('Should have "Save summary" button', () => {
-    cy.get('.downloader').find('button').should('contain', 'Save summary')
+
+  it('Should open download modal with active download button', () => {
+    modal.openModal('Save summary')
+    modal.getModal().within(() => {
+      cy.findByTestId('download-acknowledgment').should('not.exist')
+      modal.getPIICheckboxLabel().should('not.exist')
+      modal.getSaveButton().should('not.have.attr', 'disabled')
+    })
+  })
+
+  it('Should download event data', () => {
+    const eventDownloadData =
+      'ID,DESCRIPTION,CATEGORY,HITS,ACCOUNTS AFFECTED\nTest-Eval-1,This is a test evaluator.,Delinquency,1000,450\nTest-Eval-2,Test evaluator.,Bankruptcy,85,17'
+
+    modal.openModal('Save summary')
+
+    modal.getModal().within(() => {
+      modal.getSaveButton().click()
+      cy.readFile('cypress/downloads/Browser-testing-event.csv')
+        .should('exist')
+        .and('contain', eventDownloadData)
+    })
+
+    modal.getModal().should('not.be.visible')
   })
 })

--- a/front-end/cypress/helpers/modalHelpers.ts
+++ b/front-end/cypress/helpers/modalHelpers.ts
@@ -1,4 +1,8 @@
- 
+import {
+  downloadAcknowledgmentLabelText,
+  downloadAcknowledgmentText
+} from '@src/constants/privacyText'
+
 export const getInputByLabel = (label: string) => {
   return cy
     .contains('label', label)
@@ -7,9 +11,6 @@ export const getInputByLabel = (label: string) => {
       cy.get(`#${String(id)}`)
     })
 }
-
-const piiCheckboxLabel =
-  'I confirm that I am knowingly downloading PII or CI and understand that I am responsible for safeguarding this data'
 
 export class Metro2Modal {
   getModal() {
@@ -27,19 +28,20 @@ export class Metro2Modal {
     })
   }
 
+  getDownloadAcknowledgment() {
+    return cy.findByTestId('download-acknowledgment')
+  }
+
   verifyPrivacyMessage() {
-    // This is just an excerpt; could test the whole thing
-    cy.contains(
-      'I understand that by downloading data from this system, I will be accessing Personally Identifiable Information (PII) and Confidential Information (CI)'
-    ).should('be.visible')
+    cy.contains(downloadAcknowledgmentText).should('be.visible')
   }
 
   getPIICheckboxLabel() {
-    return cy.get('label').contains(piiCheckboxLabel)
+    return cy.contains(downloadAcknowledgmentLabelText)
   }
 
   getPIICheckbox() {
-    return getInputByLabel(piiCheckboxLabel)
+    return getInputByLabel(downloadAcknowledgmentLabelText)
   }
 
   checkPIICheckbox() {

--- a/front-end/src/components/Modal/DownloadModal.tsx
+++ b/front-end/src/components/Modal/DownloadModal.tsx
@@ -1,5 +1,8 @@
 import { Button, ButtonGroup, Checkbox } from '@cfpb/design-system-react'
-import { downloadAcknowledgment } from '@src/constants/privacyText'
+import {
+  downloadAcknowledgmentLabelText,
+  downloadAcknowledgmentText
+} from '@src/constants/privacyText'
 import type { ReactElement } from 'react'
 import { useEffect, useState } from 'react'
 import CopyUrl from '../CopyUrl'
@@ -82,16 +85,18 @@ export default function DownloadModal({
       </div>
       <div className='block block--sub'>{content}</div>
       {requirePrivacyAcknowledgment && (
-        <fieldset className='o-form__fieldset block block--sub'>
+        <fieldset
+          className='o-form__fieldset block block--sub'
+          data-test-id='download-acknowledgment'>
           <legend className='h4'>{privacyHeader}</legend>
-          <p>{downloadAcknowledgment}</p>
+          <p>{downloadAcknowledgmentText}</p>
           <div className='u-mt15'>
             <Checkbox
               id='confirmPII'
               isLarge
               checked={isChecked}
               data-testid='pii-checkbox'
-              label='I confirm that I am knowingly downloading PII or CI and understand that I am responsible for safeguarding this data.'
+              label={downloadAcknowledgmentLabelText}
               onChange={onChange}
             />
           </div>
@@ -104,7 +109,7 @@ export default function DownloadModal({
             appearance='primary'
             id='downloadCSV'
             iconRight='download'
-            disabled={!isChecked}
+            disabled={requirePrivacyAcknowledgment && !isChecked}
             label={buttonText}
             data-testid='csv-download-button'
             className='a-btn a-btn--full-on-xs'

--- a/front-end/src/constants/privacyText.ts
+++ b/front-end/src/constants/privacyText.ts
@@ -1,2 +1,5 @@
-export const downloadAcknowledgment =
+export const downloadAcknowledgmentText =
   'I understand that by downloading data from this system, I will be accessing Personally Identifiable Information (PII) and Confidential Information (CI).'
+
+export const downloadAcknowledgmentLabelText =
+  'I confirm that I am knowingly downloading PII or CI and understand that I am responsible for safeguarding this data.'

--- a/front-end/src/pages/Event/components/EventDownloader.tsx
+++ b/front-end/src/pages/Event/components/EventDownloader.tsx
@@ -63,6 +63,7 @@ export default function EventDownloader({
         iconRight='download'
         onClick={onClick}
         size='default'
+        data-testid='download-event-summary'
       />
       <div id='portal' />
       <DownloadModal

--- a/front-end/src/utils/downloads.ts
+++ b/front-end/src/utils/downloads.ts
@@ -44,6 +44,17 @@ export const generateDownloadData = <T>(
 }
 
 /**
+ * replaceSpaces()
+ *
+ * Formats a string by replacing spaces with hyphens.
+ *
+ * @param {string} str -String to format
+ * @returns {string} - Formatted string
+ *
+ */
+export const replaceSpaces = (str: string): string => str.split(' ').join('-')
+
+/**
  * downloadData()
  *
  * Initiates a download for a locally-generated file as a blob.
@@ -53,17 +64,17 @@ export const generateDownloadData = <T>(
  * @param {string} fileType - Type for the file
  *
  */
-//
 export const downloadData = (
   file: Buffer | string,
   fileName: string,
   fileType = 'data:text/csv'
 ): void => {
+  const formattedFileName = replaceSpaces(fileName)
   const blob = new Blob([file as BlobPart], { type: fileType })
   const url = globalThis.URL.createObjectURL(blob)
   const link = document.createElement('a')
   link.href = url
-  link.download = fileName
+  link.download = formattedFileName
   link.click()
   globalThis.URL.revokeObjectURL(url)
 }


### PR DESCRIPTION
Fix issue that was preventing downloads on the event page.

## Changes

- Only disable download modal button when privacy acknowledgment is required
- Add Cypress test for enabled download button on event page modal
- Add tests for downloaded data on Event and Evaluator pages
- Move privacy acknowledgment content to separate file

## Testing

1. Front end tests should pass in PR checks
2. To manually validate, check out branch, navigate to event view, and verify that downloading works

