### PR TITLE
Update Django to 4.2.30

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,7 +1,7 @@
 APScheduler==3.11.0
 asgiref==3.8.1
 coverage==7.8.0
-Django==4.2.29
+Django==4.2.30
 psycopg2-binary==2.9.10
 ruff==0.11.4
 boto3==1.37.29


### PR DESCRIPTION
This updates Django 4.2.30 to remediate CVE-2026-3902.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests