### PR TITLE
Upgrade Django to 5.2 and bump other pinned dependencies

### DIFF
--- a/django/parse_m2/tests/test_models.py
+++ b/django/parse_m2/tests/test_models.py
@@ -84,7 +84,7 @@ class ParserModelsTestCase(TestCase):
 
     def test_get_all_account_activity_returns_no_results(self):
         self.create_exam_activity()
-        event = Metro2Event(name="test_exam")
+        event = Metro2Event.objects.create(name="test_exam")
         result = event.get_all_account_activity()
 
         self.assertEqual(0, len(result))

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,7 +1,6 @@
 APScheduler==3.11.2
 asgiref==3.11.1
 coverage==7.13.5
-cryptography==46.0.7  # not required directly by Metro2; but pinned to avoid CVEs
 Django==5.2.13
 psycopg==3.3.3
 psycopg-binary==3.3.3

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,15 +1,17 @@
-APScheduler==3.11.0
-asgiref==3.8.1
-coverage==7.8.0
-Django==4.2.30
-psycopg2-binary==2.9.10
-ruff==0.11.4
-boto3==1.37.29
-djangorestframework==3.16.0
-django-auth-adfs==1.15.0
-django-filter==25.1
-gunicorn==23.0.0
-whitenoise==6.9.0
-smart-open[s3]==7.1.0
+APScheduler==3.11.2
+asgiref==3.11.1
+coverage==7.13.5
+cryptography==46.0.7  # not required directly by Metro2; but pinned to avoid CVEs
+Django==5.2.13
+psycopg==3.3.3
+psycopg-binary==3.3.3
+ruff==0.15.11
+boto3==1.42.91
+djangorestframework==3.17.1
+django-auth-adfs==1.16.0
+django-filter==25.2
+gunicorn==25.3.0
+whitenoise==6.12.0
+smart-open[s3]==7.6.0
 urllib3==2.6.3  # not required directly by Metro2; but pinned to avoid CVEs
 yappi==1.7.6

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -12,5 +12,4 @@ django-filter==25.2
 gunicorn==25.3.0
 whitenoise==6.12.0
 smart-open[s3]==7.6.0
-urllib3==2.6.3  # not required directly by Metro2; but pinned to avoid CVEs
 yappi==1.7.6


### PR DESCRIPTION
This PR updates Django to the latest 5.2 LTS release and bumps other dependencies while we're there. 

I've also removed to `urllib3` pin, since we're now pulling in an upstream version equal to what we were pinning.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests

