### PR TITLE
Remove APScheduler, simplify running tasks

### DIFF
--- a/django/parse_m2/apps.py
+++ b/django/parse_m2/apps.py
@@ -5,12 +5,3 @@ class ParseM2Config(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'parse_m2'
     verbose_name='Parse M2'
-
-    # Override built-in ready() method to ensure task scheduler is started
-    #   exactly once when the application starts up
-    def ready(self):
-        from users import task
-
-        task.start()
-
-        return super().ready()

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,4 +1,3 @@
-APScheduler==3.11.2
 asgiref==3.11.1
 coverage==7.13.5
 Django==5.2.13

--- a/django/users/management/commands/run_tasks.py
+++ b/django/users/management/commands/run_tasks.py
@@ -1,5 +1,5 @@
-import logging
 import datetime
+import logging
 
 from django.core.management.base import BaseCommand
 
@@ -8,6 +8,7 @@ from users.task import (
     disable_non_privileged_inactive_users,
     disable_privileged_inactive_users,
 )
+
 
 logger = logging.getLogger(__name__)
 

--- a/django/users/management/commands/run_tasks.py
+++ b/django/users/management/commands/run_tasks.py
@@ -1,0 +1,30 @@
+import logging
+import datetime
+
+from django.core.management.base import BaseCommand
+
+from users.task import (
+    clear_expired_sessions,
+    disable_non_privileged_inactive_users,
+    disable_privileged_inactive_users,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Runs 3 recurring jobs. Intended to be run daily.\n" +\
+        " - Deactivate inactive users (privileged)\n" + \
+        " - Deactivate inactive users (non-privileged)\n" + \
+        " - Clear expired Django sessions (only runs on Mondays)"
+
+    def handle(self, *args, **options):
+        logger.info("Starting tasks...")
+        disable_non_privileged_inactive_users()
+        disable_privileged_inactive_users()
+        if datetime.date.today().weekday() == 0:
+            clear_expired_sessions()
+
+        logger.info(
+            self.style.SUCCESS("Finished running all tasks.")
+        )

--- a/django/users/task.py
+++ b/django/users/task.py
@@ -1,12 +1,9 @@
 import logging
 from datetime import timedelta
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.utils import timezone
-
-from apscheduler.schedulers.background import BackgroundScheduler
 
 
 def disable_non_privileged_inactive_users():
@@ -29,11 +26,3 @@ def clear_expired_sessions():
     logger = logging.getLogger('users.tasks.clear_expired_sessions')
     logger.info("Removing expired session records from the database.")
     call_command('clearsessions')
-
-def start():
-        scheduler = BackgroundScheduler()
-        if settings.SSO_ENABLED:
-            scheduler.add_job(disable_non_privileged_inactive_users, 'interval', days=1)
-            scheduler.add_job(disable_privileged_inactive_users, 'interval', days=1)
-        scheduler.add_job(clear_expired_sessions, 'interval', weeks=1)
-        scheduler.start()


### PR DESCRIPTION
Ticket: 809


## Changes

- Remove APScheduler. APScheduler was not implemented correctly for Django, since it would start the scheduler every time a management command was run, and because the tasks would not close their database connections after completing, which left many open database connections that remained idle for a long time.
- Add a management command to do the tasks that APScheduler was doing. The command is designed to be run daily.


## Testing

1. `docker compose up`
2. in another terminal window, `docker compose exec django sh`
3. in the shell that opens, `python manage.py run_tasks`
4. output should show that the "disable inactive users" tasks were run. If it's Monday, the "clear expired sessions" task should run too.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) ➡️ 
