### PR TITLE
Pin our GitHub actions to commit SHAs

### DIFF
--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -15,8 +15,8 @@ jobs:
         working-directory: django
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13
       - run: python -m pip install --upgrade pip -r ./requirements.txt
@@ -30,8 +30,8 @@ jobs:
         working-directory: django
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.13
       - run: python -m pip install --upgrade pip -r ./requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Enable corepack
         run: corepack enable
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: yarn


### PR DESCRIPTION
Rather than use a general version number like `v6`, reference specific commits of GitHub Actions. This avoids potential compromise of major version numbers in minor or patch releases in favor of a known-good SHA.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
