### PR TITLE
Add /version endpoint

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -29,7 +29,6 @@ RUN apk update --no-cache && \
     apk add libffi-dev && \
     pip install --upgrade pip
 
-
 # Add `$HOME/.local/bin` to PATH
 RUN echo 'export PATH=$HOME/.local/bin:$PATH' >> /etc/profile
 
@@ -40,7 +39,12 @@ RUN pip install -r ./requirements.txt
 # Delete build dependencies
 RUN apk del .build-deps
 
+# Write the VERSION arg to a file in the parent of APP_HOME
+ARG VERSION=unknown
+RUN echo "$VERSION" > $APP_HOME/../version.txt
+
 RUN chown -R $USERNAME:$USERNAME $APP_HOME
+
 # Create the user
 USER $USERNAME
 

--- a/django/django_application/settings/base.py
+++ b/django/django_application/settings/base.py
@@ -17,6 +17,10 @@ import logging
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
+# Load the version string from a file, if that file exists in the parent dir.
+VERSION_FILE = BASE_DIR.parent / "version.txt"
+VERSION = VERSION_FILE.read_text().strip() if VERSION_FILE.exists() else "unknown"
+
 FRONT_END_DIR = BASE_DIR.parent / 'front-end'
 
 

--- a/django/django_application/tests/test_views.py
+++ b/django/django_application/tests/test_views.py
@@ -1,4 +1,7 @@
-from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+from rest_framework.test import APITestCase
 
 
 class TestBadRequestView(TestCase):
@@ -10,3 +13,19 @@ class TestBadRequestView(TestCase):
     def test_does_not_return_bad_request(self):
         response = self.client.get('/api/all-evaluator-metadata/')
         self.assertNotEqual(response.status_code, 400)
+
+
+class TestVersionEndpoint(APITestCase):
+
+    def test_unauth_does_not_get_version(self):
+        response = self.client.get("/api/version/")
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(VERSION="testversion")
+    def test_gets_version(self):
+        user = get_user_model().objects.create_user(username="testuser")
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get("/api/version/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"version": "testversion"})

--- a/django/django_application/urls.py
+++ b/django/django_application/urls.py
@@ -21,7 +21,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import include, path, re_path
 from django.views.generic import TemplateView
 
-from django_application import views as error_view
+from django_application import views as app_views
 from evaluate_m2 import urls as evaluate_m2_urls
 from evaluate_m2 import views as eval_views
 from users import views
@@ -32,7 +32,8 @@ urlpatterns = [
     path('api/all-evaluator-metadata/', eval_views.download_evaluator_metadata_csv),
     path('api/events/', include(evaluate_m2_urls)),
     path('api/users/', views.users_view),
-    path('api/users/<int:user_id>/', views.users_view)
+    path('api/users/<int:user_id>/', views.users_view),
+    path('api/version/', app_views.version),
 ]
 
 with suppress(ImproperlyConfigured):
@@ -42,7 +43,7 @@ with suppress(ImproperlyConfigured):
     ]
 
 # All erroneous API calls to return 400: bad request
-urlpatterns.append(re_path(r'api(?:.*)?', error_view.bad_request_view ))
+urlpatterns.append(re_path(r'api(?:.*)?', app_views.bad_request_view ))
 
 # Fall through route: Handle all other URLs through the front end
 urlpatterns.append(

--- a/django/django_application/views.py
+++ b/django/django_application/views.py
@@ -1,6 +1,15 @@
+from django.conf import settings
+
 from rest_framework import status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+
+
+@api_view()
+@permission_classes([IsAuthenticated])
+def version(request):
+    return Response({"version": settings.VERSION})
 
 
 @api_view()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,9 @@ services:
     image: django-m2:local
     build:
       context: ./django
+      args:
+        # Set the VERSION env var and run compose build to set this
+        VERSION: ${VERSION:-unknown}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
This change adds a `/api/version/` endpoint to the backend that will return the contents of a `version.txt` in the parent directory of `django/`.

The `Dockerfile` will populate that file on image build if provided a `VERSION` argument, otherwise it will be "unknown". The compose file will pass a `VERSION` env var as that argument to the image build. I've tried to ensure that writing this file is as far down the Dockerfile as possible, to maximize layer caching. 

You can test this by setting a `VERSION` env var and running the build, like:

```
VERSION="testversion" docker compose up --build
```

Then authenticate at http://localhost:8000/admin and visit http://localhost:8000/api/version/ and see the version returned as a JSON response.

This will be accompanied by an internal PR for our image build job that passes the git SHAs as the VERSION argument to `docker build`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
