### PR TITLE
Upgrade URLLib

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -12,3 +12,4 @@ gunicorn==25.3.0
 whitenoise==6.12.0
 smart-open[s3]==7.6.0
 yappi==1.7.6
+urllib3==2.7.0  # Not required directly by Metro2; pinned to avoid CVEs


### PR DESCRIPTION
Pin `urllib3` to latest version to avoid a high CVE affecting an earlier version.

Internal ticket: #1043

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: