### PR TITLE
Add directory param to parsing methods

### DIFF
--- a/django/parse_m2/initiate_parsing_local.py
+++ b/django/parse_m2/initiate_parsing_local.py
@@ -18,20 +18,9 @@ from parse_m2.models import Metro2Event
 def parse_local_file(
     event: Metro2Event,
     filepath: str,
-    skip_existing: bool = True,
     collection: str = None
 ):
     logger = logging.getLogger('parse_m2.parse_local_file')
-    full_name = f"local:{filepath}"
-
-    # If the skip_existing flag is set to True, and this file
-    # already exists on this event, don't parse it again.
-    if skip_existing and parsed_file_exists(event, full_name):
-        logger = logging.getLogger('parse_m2.parse_local_file')
-        logger.debug(
-            f"Skipping existing file {full_name}, because skip_existing = True"
-        )
-        return
 
     # Instantiate a parser
     parser = M2FileParser(event, full_name, collection)
@@ -47,33 +36,29 @@ def parse_local_file(
         logger.error(f"There was an error opening the file: {e}")
 
 def parse_zip_file_contents(
-    zip_path: str, event: Metro2Event, skip_existing: bool, collection: str = None
+    zip_path: str, event: Metro2Event, collection: str = None
 ):
     with zipfile.ZipFile(zip_path, 'r') as zipf:
         for f in zipf.filelist:
             full_name = f"local:ZIP:{zip_path}:{f.filename}"
 
-            # If the skip_existing flag is set to True, and this file
-            # already exists on this event, don't parse it again.
-            if skip_existing and parsed_file_exists(event, full_name):
+            # If this file already exists on this event, don't parse it again.
+            if parsed_file_exists(event, full_name):
                 logger = logging.getLogger('parse_m2.local.parse_zip_file_contents')
-                logger.debug(
-                    f"Skipping existing file {full_name}, because skip_existing = True"
-                )
+                logger.debug(f"Skipping existing file {full_name}")
                 return
 
             parse_file_from_zip(f, zipf, full_name, event, collection)
 
 def parse_files_from_local_filesystem(
-    event: Metro2Event, skip_existing: bool = True, collection: str = None
+    event: Metro2Event, directory: str = None, collection: str = None
 ):
     """
     Parse all files in the local filesystem location indicated by
     event.directory, and save them to event. For any files that look like
     zip files, iterate through each file in the zip and parse each one.
 
-    If skip_existing is True, the parser will not parse a file if one with
-    a matching name already exists.
+    The parser will not parse a file if one with a matching name already exists.
     """
     logger = logging.getLogger('parse_m2.parse_files_from_local_filesystem')
 
@@ -88,6 +73,11 @@ def parse_files_from_local_filesystem(
             if is_zip_file(filename):
                 parse_zip_file_contents(
                     filepath, event, collection
+                )
+            elif parsed_file_exists(event, file_name_local(filepath)):
+                # If this file already exists on this event, don't parse it again.
+                logger.debug(
+                    f"Skipping existing file {file_name_local(filepath)}"
                 )
             elif is_data_file(filename):
                 parse_local_file(event, filepath, collection)

--- a/django/parse_m2/initiate_parsing_local.py
+++ b/django/parse_m2/initiate_parsing_local.py
@@ -3,11 +3,11 @@ import os
 import zipfile
 
 from parse_m2.initiate_parsing_utils import (
-    data_file,
+    is_data_file,
+    is_zip_file,
     log_invalid_file_extension,
     parse_file_from_zip,
     parsed_file_exists,
-    zip_file,
 )
 from parse_m2.m2_parser import M2FileParser
 from parse_m2.models import Metro2Event
@@ -85,9 +85,11 @@ def parse_files_from_local_filesystem(
         filepath = os.path.join(data_directory, filename)
 
         if os.path.isfile(filepath):
-            if zip_file(filename):
-                parse_zip_file_contents(filepath, event, skip_existing, collection)
-            elif data_file(filename):
-                parse_local_file(event, filepath, skip_existing, collection)
+            if is_zip_file(filename):
+                parse_zip_file_contents(
+                    filepath, event, collection
+                )
+            elif is_data_file(filename):
+                parse_local_file(event, filepath, collection)
             else:
                 log_invalid_file_extension(event, filename, skip_existing, logger)

--- a/django/parse_m2/initiate_parsing_local.py
+++ b/django/parse_m2/initiate_parsing_local.py
@@ -56,14 +56,15 @@ def parse_files_from_local_filesystem(
 ):
     """
     Parse all files in the local filesystem location indicated by
-    event.directory, and save them to event. For any files that look like
+    directory param if present, or default to event.directory.
+    Save them to event. For any files that look like
     zip files, iterate through each file in the zip and parse each one.
 
     The parser will not parse a file if one with a matching name already exists.
     """
     logger = logging.getLogger('parse_m2.parse_files_from_local_filesystem')
 
-    data_directory: str = event.directory
+    data_directory: str = directory if directory else event.directory
 
     # Iterate over files in the directory
     for filename in os.listdir(data_directory):

--- a/django/parse_m2/initiate_parsing_local.py
+++ b/django/parse_m2/initiate_parsing_local.py
@@ -22,16 +22,14 @@ def parse_local_file(
 ):
     logger = logging.getLogger('parse_m2.parse_local_file')
 
-    # Instantiate a parser
     parser = M2FileParser(event, full_name, collection)
 
-    logger.debug(f"Parsing local file: {filepath}")
+    logger.info(f"Parsing local file: {filepath}")
     try:
         with open(filepath) as fstream:
             file_size = os.path.getsize(filepath)
-            # Parse the file
             parser.parse_file_contents(fstream, file_size)
-            logger.info(f'File {os.path.basename(fstream.name)} written to database.')
+            logger.debug("Parsing completed")
     except FileNotFoundError as e:
         logger.error(f"There was an error opening the file: {e}")
 
@@ -64,9 +62,9 @@ def parse_files_from_local_filesystem(
 
     data_directory: str = event.directory
 
-    # iterate over files in the directory
+    # Iterate over files in the directory
     for filename in os.listdir(data_directory):
-        logger.info(f"Encountered file in local data path: {filename}")
+        logger.debug(f"Encountered file in local data path: {filename}")
         filepath = os.path.join(data_directory, filename)
 
         if os.path.isfile(filepath):
@@ -82,4 +80,6 @@ def parse_files_from_local_filesystem(
             elif is_data_file(filename):
                 parse_local_file(event, filepath, collection)
             else:
-                log_invalid_file_extension(event, filename, skip_existing, logger)
+                # If the file is neither zip nor datafile, log an error and skip
+                logger.info("Skipping. Does not match an allowed file type.")
+                log_invalid_file_extension(event, filename)

--- a/django/parse_m2/initiate_parsing_local.py
+++ b/django/parse_m2/initiate_parsing_local.py
@@ -15,6 +15,9 @@ from parse_m2.models import Metro2Event
 
 ############################################
 # Methods for parsing files from the local filesystem
+def file_name_local(filepath) -> str:
+    return f"local:{filepath}"
+
 def parse_local_file(
     event: Metro2Event,
     filepath: str,
@@ -22,7 +25,7 @@ def parse_local_file(
 ):
     logger = logging.getLogger('parse_m2.parse_local_file')
 
-    parser = M2FileParser(event, full_name, collection)
+    parser = M2FileParser(event, file_name_local(filepath), collection)
 
     logger.info(f"Parsing local file: {filepath}")
     try:

--- a/django/parse_m2/initiate_parsing_s3.py
+++ b/django/parse_m2/initiate_parsing_s3.py
@@ -35,7 +35,7 @@ def parse_s3_file(
 
     # Parse the file
     fstream = file.get()["Body"]
-    logger.debug(f"Successfully opened file: {full_name}. Now parsing...")
+    logger.debug(f"Successfully opened file: {file_name_s3(file)}. Now parsing...")
     parser.parse_file_contents(fstream, file.size)
     logger.info(f'File {full_name} written to database.')
 
@@ -89,4 +89,6 @@ def parse_files_from_s3_bucket(
         elif is_data_file(file.key):
             parse_s3_file(file, event, collection)
         else:
-            log_invalid_file_extension(event, file.key, skip_existing, logger)
+            # If the file is neither zip nor datafile, log the error and skip.
+            logger.info("Skipping. Does not match an allowed file type.")
+            log_invalid_file_extension(event, file.key)

--- a/django/parse_m2/initiate_parsing_s3.py
+++ b/django/parse_m2/initiate_parsing_s3.py
@@ -4,11 +4,11 @@ import zipfile
 
 from django_application.s3_utils import s3_bucket_files
 from parse_m2.initiate_parsing_utils import (
-    data_file,
+    is_data_file,
+    is_zip_file,
     log_invalid_file_extension,
     parse_file_from_zip,
     parsed_file_exists,
-    zip_file,
 )
 from parse_m2.m2_parser import M2FileParser
 from parse_m2.models import Metro2Event
@@ -96,9 +96,9 @@ def parse_files_from_s3_bucket(
         logger.info(f"Encountered file: {file.key}")
         # TODO: Handle errors connecting to bucket and opening files
 
-        if zip_file(file.key):
-            parse_zip_file_contents_S3(file, event, file.key, skip_existing, collection)
-        elif data_file(file.key):
-            parse_s3_file(file, event, skip_existing, collection)
+        if is_zip_file(file.key):
+            parse_zip_file_contents_S3(file, event, file.key, collection)
+        elif is_data_file(file.key):
+            parse_s3_file(file, event, collection)
         else:
             log_invalid_file_extension(event, file.key, skip_existing, logger)

--- a/django/parse_m2/initiate_parsing_s3.py
+++ b/django/parse_m2/initiate_parsing_s3.py
@@ -25,19 +25,22 @@ from parse_m2.models import Metro2Event
 # For more on how to set credentials:
 # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
 
+def file_name_s3(file) -> str:
+    return f"s3:{file.key}"
+
 def parse_s3_file(
     file, event: Metro2Event, collection: str = None,
 ):
     logger = logging.getLogger('parse_m2.parse_s3_file')
 
     # Instantiate a parser
-    parser = M2FileParser(event, full_name, collection)
+    parser = M2FileParser(event, file_name_s3(file), collection)
 
     # Parse the file
     fstream = file.get()["Body"]
     logger.debug(f"Successfully opened file: {file_name_s3(file)}. Now parsing...")
     parser.parse_file_contents(fstream, file.size)
-    logger.info(f'File {full_name} written to database.')
+    logger.info(f'File {file_name_s3(file)} written to database.')
 
 def parse_zip_file_contents_S3(
     zip_obj,

--- a/django/parse_m2/initiate_parsing_s3.py
+++ b/django/parse_m2/initiate_parsing_s3.py
@@ -70,16 +70,19 @@ def parse_files_from_s3_bucket(
 ):
     """
     Parse all files in the folder of the S3 bucket location indicated by
-    event.directory, and save them to event. For any files that look like zip
+    event.directory, (or directory arg if present) and save them to event.
+    For any files that look like zip
     files, iterate through each file in the zip and parse each one.
 
     The parser will not parse a file if one with a matching name already exists.
     """
     logger = logging.getLogger('parse_m2.parse_files_from_s3_bucket')
 
+    # Directory argument overrides event.directory if present
+    parse_directory = directory if directory else event.directory
 
-    logger.info(f"Finding all files in S3 bucket with prefix: {event.directory}")
-    for file in s3_bucket_files(event.directory):
+    logger.info(f"Finding all files in S3 bucket with prefix: {parse_directory}")
+    for file in s3_bucket_files(parse_directory):
         logger.info(f"Encountered file: {file.key}")
         # TODO: Handle errors connecting to bucket and opening files
 

--- a/django/parse_m2/initiate_parsing_s3.py
+++ b/django/parse_m2/initiate_parsing_s3.py
@@ -26,19 +26,9 @@ from parse_m2.models import Metro2Event
 # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
 
 def parse_s3_file(
-    file, event: Metro2Event, skip_existing: bool = True, collection: str = None
+    file, event: Metro2Event, collection: str = None,
 ):
     logger = logging.getLogger('parse_m2.parse_s3_file')
-    full_name = f"s3:{file.key}"
-
-    # If the skip_existing flag is set to True, and this file
-    # already exists on this event, don't parse it again.
-    if skip_existing and parsed_file_exists(event, full_name):
-        logger = logging.getLogger('parse_m2.parse_s3_file')
-        logger.debug(
-            f"Skipping existing file {full_name}, because skip_existing = True"
-        )
-        return
 
     # Instantiate a parser
     parser = M2FileParser(event, full_name, collection)
@@ -53,7 +43,6 @@ def parse_zip_file_contents_S3(
     zip_obj,
     event: Metro2Event,
     zipfile_name: str,
-    skip_existing: bool,
     collection: str = None
 ):
     # TODO: If the files are large (>2GB), this method of streaming
@@ -65,28 +54,23 @@ def parse_zip_file_contents_S3(
         for f in zipf.filelist:
             full_name = f"s3:{zipfile_name}:{f.filename}"
 
-            # If the skip_existing flag is set to True, and this file
-            # already exists on this event, don't parse it again.
-            if skip_existing and parsed_file_exists(event, full_name):
+            # If this file already exists on this event, don't parse it again.
+            if parsed_file_exists(event, full_name):
                 logger = logging.getLogger('parse_m2.s3.parse_zip_file_contents')
-                logger.debug(
-                    f"Skipping existing file {full_name}, because "
-                    "skip_existing = True"
-                )
+                logger.debug(f"Skipping existing file {full_name}")
                 return
 
             parse_file_from_zip(f, zipf, full_name, event, collection)
 
 def parse_files_from_s3_bucket(
-    event: Metro2Event, skip_existing: bool = True, collection: str = None
+    event: Metro2Event, directory: str = None, collection: str = None
 ):
     """
     Parse all files in the folder of the S3 bucket location indicated by
     event.directory, and save them to event. For any files that look like zip
     files, iterate through each file in the zip and parse each one.
 
-    If skip_existing is True, the parser will not parse a file if one with
-    a matching name already exists.
+    The parser will not parse a file if one with a matching name already exists.
     """
     logger = logging.getLogger('parse_m2.parse_files_from_s3_bucket')
 
@@ -98,6 +82,10 @@ def parse_files_from_s3_bucket(
 
         if is_zip_file(file.key):
             parse_zip_file_contents_S3(file, event, file.key, collection)
+
+        elif parsed_file_exists(event, file_name_s3(file)):
+            # If this file already exists on this event, don't parse it again.
+            logger.debug(f"Skipping existing file {file_name_s3(file)}")
         elif is_data_file(file.key):
             parse_s3_file(file, event, collection)
         else:

--- a/django/parse_m2/initiate_parsing_utils.py
+++ b/django/parse_m2/initiate_parsing_utils.py
@@ -17,10 +17,10 @@ def get_extension(filename: str) -> str:
     return filename.split('.')[-1].lower()
 
 def parse_file_from_zip(
-    f: ZipInfo, 
-    zip_file: ZipFile, 
-    full_name: str, 
-    event: Metro2Event, 
+    f: ZipInfo,
+    zip_file: ZipFile,
+    full_name: str,
+    event: Metro2Event,
     collection: str = None
 ):
     logger = logging.getLogger('parse_m2.parse_file_from_zip')

--- a/django/parse_m2/initiate_parsing_utils.py
+++ b/django/parse_m2/initiate_parsing_utils.py
@@ -27,8 +27,8 @@ def parse_file_from_zip(
     filename = f.filename
     logger.debug(f"Encountered file in zipfile: {filename}")
     if not f.is_dir():
-        parser = M2FileParser(event, full_name, collection)
         if is_data_file(filename):
+            parser = M2FileParser(event, full_name, collection)
             try:
                 with zip_file.open(filename) as fstream:
                     logger.info(f"Parsing file {full_name}")
@@ -37,11 +37,7 @@ def parse_file_from_zip(
             except NotImplementedError as e:
                 parser.update_file_record(status="Not parsed", msg=f"File skipped: {e}")
         else:
-            file_ext = get_extension(filename)
-            error_message = (
-                f"File skipped because of invalid file extension: .{file_ext}"
-            )
-            parser.update_file_record(status="Not parsed", msg=error_message)
+            log_invalid_file_extension(event, full_name)
             logger.debug(
                 "Skipping file within zip. Does not match an allowed file type."
             )

--- a/django/parse_m2/initiate_parsing_utils.py
+++ b/django/parse_m2/initiate_parsing_utils.py
@@ -25,15 +25,15 @@ def parse_file_from_zip(
 ):
     logger = logging.getLogger('parse_m2.parse_file_from_zip')
     filename = f.filename
-    logger.info(f"Encountered file in zipfile: {filename}")
+    logger.debug(f"Encountered file in zipfile: {filename}")
     if not f.is_dir():
         parser = M2FileParser(event, full_name, collection)
         if is_data_file(filename):
             try:
                 with zip_file.open(filename) as fstream:
-                    logger.debug(f"Parsing file {full_name}...")
+                    logger.info(f"Parsing file {full_name}")
                     parser.parse_file_contents(fstream, f.file_size)
-                    logger.info("file written to db")
+                    logger.debug("Parsing completed.")
             except NotImplementedError as e:
                 parser.update_file_record(status="Not parsed", msg=f"File skipped: {e}")
         else:
@@ -42,7 +42,7 @@ def parse_file_from_zip(
                 f"File skipped because of invalid file extension: .{file_ext}"
             )
             parser.update_file_record(status="Not parsed", msg=error_message)
-            logger.info(
+            logger.debug(
                 "Skipping file within zip. Does not match an allowed file type."
             )
 

--- a/django/parse_m2/initiate_parsing_utils.py
+++ b/django/parse_m2/initiate_parsing_utils.py
@@ -5,11 +5,11 @@ from parse_m2.m2_parser import M2FileParser
 from parse_m2.models import Metro2Event
 
 
-def data_file(filename: str) -> bool:
+def is_data_file(filename: str) -> bool:
     data_file_extensions = ['txt']
     return get_extension(filename) in data_file_extensions
 
-def zip_file(filename: str) -> bool:
+def is_zip_file(filename: str) -> bool:
     zip_file_extensions = ['zip']
     return get_extension(filename) in zip_file_extensions
 
@@ -28,7 +28,7 @@ def parse_file_from_zip(
     logger.info(f"Encountered file in zipfile: {filename}")
     if not f.is_dir():
         parser = M2FileParser(event, full_name, collection)
-        if data_file(filename):
+        if is_data_file(filename):
             try:
                 with zip_file.open(filename) as fstream:
                     logger.debug(f"Parsing file {full_name}...")

--- a/django/parse_m2/initiate_parsing_utils.py
+++ b/django/parse_m2/initiate_parsing_utils.py
@@ -59,19 +59,17 @@ def parsed_file_exists(event: Metro2Event, filename: str) -> bool:
     return file.exists()
 
 def log_invalid_file_extension(
-    event: Metro2Event, filename: str, skip_existing: bool, logger
+    event: Metro2Event, filename: str,
 ):
-    if parsed_file_exists(event, filename) and skip_existing:
-        # If the skip_existing flag is set to True, and this file
-        # already exists on this event, don't log it again.
-        logger.debug(f"Skipping existing file {filename}, because skip_existing = True")
-    else:
-        # If no skip_existing flag or it hasn't been logged before, log it.
-        error_message = (
-            "File skipped because of invalid file extension: "
-            f".{get_extension(filename)}"
-        )
-        M2FileParser(event, filename).update_file_record(
-            status="Not parsed", msg=error_message
-        )
-        logger.info("Skipping. Does not match an allowed file type.")
+    """
+    For the given file, create a M2DataFile record with status
+    'Not parsed' and informative error message, which will show
+    up in the list of files for the event.
+    """
+    error_message = (
+        "File skipped because of invalid file extension: "
+        f".{get_extension(filename)}"
+    )
+    M2FileParser(event, filename).update_file_record(
+        status="Not parsed", msg=error_message
+    )

--- a/django/parse_m2/management/commands/parse.py
+++ b/django/parse_m2/management/commands/parse.py
@@ -62,13 +62,11 @@ class Command(BaseCommand):
         if settings.S3_ENABLED:
             parse_files_from_s3_bucket(
                 event,
-                skip_existing=True,
                 collection=collection
             )
         else:
             parse_files_from_local_filesystem(
                 event,
-                skip_existing=True,
                 collection=collection
             )
 

--- a/django/parse_m2/management/commands/parse.py
+++ b/django/parse_m2/management/commands/parse.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, argparser):
-        event_help = "The ID of the event record"
+        event_help = "The ID of the event record. (required)"
         argparser.add_argument(
             "-e",
             "--event_id",

--- a/django/parse_m2/management/commands/parse.py
+++ b/django/parse_m2/management/commands/parse.py
@@ -31,6 +31,18 @@ class Command(BaseCommand):
             help=event_help
         )
 
+        directory_help = (
+            "The directory to find files for parsing. When present, overrides "
+            "the 'directory' value on the Metro2Event model. Useful for when "
+            "an event has files in multiple directories that need to be parsed "
+            "separately. (optional)"
+        )
+        argparser.add_argument(
+            "-d", "--directory",
+            nargs="?", required=False,
+            help=directory_help,
+        )
+
         collection_help = (
             "A string to differentiate records from different sources "
             "or 'collections'. Used to prevent overlapping account numbers within "
@@ -48,6 +60,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         logger = logging.getLogger('commands.parse')
         event_id = options["event_id"]
+        directory = options["directory"]
         collection = options["collection"]
 
         # Fetch the Metro2Event
@@ -62,11 +75,13 @@ class Command(BaseCommand):
         if settings.S3_ENABLED:
             parse_files_from_s3_bucket(
                 event,
+                directory=directory,
                 collection=collection
             )
         else:
             parse_files_from_local_filesystem(
                 event,
+                directory=directory,
                 collection=collection
             )
 

--- a/django/parse_m2/normalize_format.py
+++ b/django/parse_m2/normalize_format.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from smart_open import open
 
 from django_application.s3_utils import s3_bucket_files, s3_session
-from parse_m2.initiate_parsing_utils import data_file
+from parse_m2.initiate_parsing_utils import is_data_file
 from parse_m2.parse_utils import get_next_line, is_header_line
 
 
@@ -30,7 +30,7 @@ def update_S3_directory_files_format(source_dir: str, destination_dir: str):
     for file in s3_bucket_files(source_dir):
         logger.debug(f"file: {file.key}")
 
-        if data_file(file.key):
+        if is_data_file(file.key):
             logger.debug("processing...")
             source_fstream = file.get()["Body"]
             destination = destination_path(file.key, destination_dir)

--- a/django/parse_m2/tests/test_initiate_parsing.py
+++ b/django/parse_m2/tests/test_initiate_parsing.py
@@ -1,12 +1,10 @@
 import os
-from unittest.mock import patch
 
 from django.test import TestCase
 
 from parse_m2.initiate_parsing_local import parse_files_from_local_filesystem
-from parse_m2.initiate_parsing_s3 import parse_files_from_s3_bucket
 from parse_m2.initiate_parsing_utils import parsed_file_exists
-from parse_m2.models import AccountActivity, M2DataFile, Metro2Event, UnparseableData
+from parse_m2.models import AccountActivity, M2DataFile, Metro2Event
 
 
 class InitiateLocalParsingTestCase(TestCase):
@@ -88,44 +86,6 @@ class InitiateLocalParsingTestCase(TestCase):
             1997
         )
 
-
-class InitiateS3ParsingTestCase(TestCase):
-    # Test for parsing files from the S3 bucket. Only run when testing manually.
-    # Before running, make sure S3 env vars are in place.
-
-    def xtest_fetch_s3(self):
-        with patch.dict('os.environ', {'AWS_PROFILE': 'prof'}):
-            exam_s3 = Metro2Event.objects.create(name="s3 exam", directory="test-tiny/")
-            parse_files_from_s3_bucket(exam_s3)
-
-            # The test directory in S3 should contain one file
-            self.assertEqual(M2DataFile.objects.count(), 1)
-            file = M2DataFile.objects.first()
-            self.assertEqual(
-                file.file_name,
-                "s3:test-tiny/m2_2k_lines_deidentified.TXT"
-            )
-
-            # The test file should contain 1998 base segments
-            self.assertEqual(AccountActivity.objects.count(), 1998)
-
-    def xtest_fetch_s3_zip(self):
-        with patch.dict('os.environ', {'AWS_PROFILE': 'prof'}):
-            exam_s3 = Metro2Event.objects.create(
-                name="other s3 exam",
-                directory="test-zipped/"
-            )
-            parse_files_from_s3_bucket(exam_s3)
-
-            # The test directory in S3 should contain one file
-            self.assertEqual(M2DataFile.objects.count(), 1)
-            file = M2DataFile.objects.first()
-            expected_name = "s3:test-zipped/one_small_file.zip:m2_2k_lines_deidentified.TXT"  # noqa: E501
-            self.assertEqual(file.file_name, expected_name)
-
-            # The test file should contain 1997 valid base segments and one unparseable
-            self.assertEqual(AccountActivity.objects.count(), 1997)
-            self.assertEqual(UnparseableData.objects.count(), 1)
 
 class InitiateParsingUtilsTestCase(TestCase):
     def setUp(self) -> None:

--- a/django/templates/admin/parse_m2/event_parse_eval.html
+++ b/django/templates/admin/parse_m2/event_parse_eval.html
@@ -24,6 +24,7 @@
                 <td>Parsing status</td>
                 <td>Parsed lines</td>
                 <td>Unparseable lines</td>
+                <td>Collection</td>
                 <td>Imported date</td>
                 <td>Error message</td>
                 <td>Parser version</td>
@@ -33,10 +34,19 @@
             {% for file in object.get_files_in_order %}
                 <tr>
                     <td>{{ file.file_name }}</td>
-                    <td>{{ file.activity_date }}</td>
+                    {% if file.activity_date %}
+                        <td>{{ file.activity_date }}</td>
+                    {% else %}
+                        <td>-</td>
+                    {% endif %}
                     <td>{{ file.parsing_status }}</td>
                     <td>{{ file.accountactivity_set.count|intcomma }}</td>
                     <td>{{ file.unparseabledata_set.count|intcomma }}</td>
+                    {% if file.collection %}
+                        <td>{{ file.collection }}</td>
+                    {% else %}
+                        <td>-</td>
+                    {% endif %}
                     <td>{{ file.timestamp|localtime }}</td>
                     <td>{{ file.error_message }}</td>
                     <td>{{ file.parser_version }}</td>
@@ -69,8 +79,16 @@
                 <tr>
                     <td>{{ result.evaluator.id }}</td>
                     <td>{{ result.hits|intcomma }}</td>
-                    <td>{{ result.inconsistency_start }}</td>
-                    <td>{{ result.inconsistency_end }}</td>
+                    {% if result.inconsistency_start %}
+                        <td>{{ result.inconsistency_start }}</td>
+                    {% else %}
+                        <td>-</td>
+                    {% endif %}
+                    {% if result.inconsistency_end %}
+                        <td>{{ result.inconsistency_end }}</td>
+                    {% else %}
+                        <td>-</td>
+                    {% endif %}
                     <td>{{ result.evaluator_version }}</td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
Various improvements to parsing process. See individual commits to see the diff separated by logical changes.

## Additions

- Add a `directory` parameter to the parsing management command. Previously, the `initiate_parsing` methods would know which files to parse based on the `directory` value on the `Metro2Event` model. This is still the default, but can be overridden by using the `directory` param on the parsing command. This is useful when the set of files for an event is more complicated than a single directory.
- Add a `collection` column to the data import summary page (visible in docker-compose at http://localhost:8000/admin/parse_m2/metro2event/1/parse_evaluate). Supports the collections feature, which was added in #45 and #47.

## Removals

- Remove a set of tests that was originally written to test parsing files from an S3 bucket. The tests were not maintained when our S3 implementation changed, and were not working. Recommend testing S3 parsing manually instead.
- Remove parameter `skip_existing` from `initiate_parsing` methods that wasn't used. When that param was `True` the parser would skip parsing files that already exist on the event. We always want that behavior, so no need for it to be a param. In order to re-parse a file, a user can delete that file and its contents from the database, then run the parser on it again.

## Changes

- Various cleanup and improvements, such as log level changes, improvements to docstrings and comments, changes to the names of helper methods.

## Testing

1. `python manage.py test`

If you want to test parsing from S3:
1. Modify the docker-compose Django settings to add creds for an S3 bucket you have access to
2. Run the application in docker-compose
3. Use the parse management command in docker-compose with a directory parameter indicating a test file in the bucket

If you want to see the parse progress admin page:
1. `docker compose build`
2. `docker compose up`
3. visit http://localhost:8000/admin/parse_m2/metro2event/1/parse_evaluate


## Checklist

- [x] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: