### PR TITLE
Update .gitignore to reflect actual repo contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,20 +2,12 @@
 **
 
 # ...except the following directories
+!.github/
+!.github/**
 !django/
 !django/**
 !front-end/
 !front-end/**
-!helm/
-!helm/**
-!build-utils/
-!build-utils/**
-!jenkins/
-!jenkins/**
-!.github/
-!.github/**
-!local_data/
-!local_data/**
 
 # ...and the following files
 !Dockerfile
@@ -23,11 +15,7 @@
 !.dockerignore
 !.gitignore
 !README.md
-!API.md
-!helm-install-local.sh
-!build-images.sh
 !.editorconfig
-!buildspec.yml
 !CODE_OF_CONDUCT.md
 !CONTRIBUTING.md
 !LICENSE
@@ -39,7 +27,6 @@
 *.sqlite3
 .coverage
 *.DS_Store
-helm/metro2/charts/
 django/static
 htmlcov/
 

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.11.1
 coverage==7.13.5
-Django==5.2.13
+Django==5.2.14
 psycopg==3.3.3
 psycopg-binary==3.3.3
 ruff==0.15.11


### PR DESCRIPTION
Clean up .gitignore, so it now reflects actual repo contents.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: