### PR TITLE
Remove environment variable list from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,6 @@ services:
 
   frontend:
     container_name: frontend
-    environment:
-      - VITE_SHOW_CFPB_HEADER
-      - VITE_ADMIN_EMAIL
-      - VITE_DOWNLOAD_ACKNOWLEDGMENT_TEXT
-      - VITE_PII_WARNING_TEXT
     build:
       context: ./front-end
       target: dev


### PR DESCRIPTION
Remove unnecessary configuration of variables in docker-compose since it's preventing changes to .env file from showing up in the UI until docker-compose is re-run.

## Removals

- environment variable list in docker-compose

## Testing

1. Check out branch and run internally.
2. Change the value of `VITE_SHOW_CFPB_HEADER` to `false` in the override .env file and note that the CFPB header is replaced with the generic one
