### PR TITLE
Display new metadata fields

### DIFF
--- a/django/evaluate_m2/models.py
+++ b/django/evaluate_m2/models.py
@@ -70,7 +70,18 @@ class EvaluatorMetadata(models.Model):
     )
     interpret_fields_last_modified = models.DateField(default=_last_modified_never)
     additional_notes = ProseEditorField(
-        extensions=_richtext_basic_options,
+        extensions= {
+            "Bold": True,
+            "Italic": True,
+            "BulletList": True,
+            "OrderedList": True,
+            "ListItem": True,
+            "Link": True,
+            "Blockquote": True,
+            "Heading": {
+                "levels": [4]
+            },
+        },
         sanitize=True,
         blank=True,
     )

--- a/front-end/cypress/component/EvaluatorMetadata.cy.tsx
+++ b/front-end/cypress/component/EvaluatorMetadata.cy.tsx
@@ -1,4 +1,5 @@
 import EvaluatorMetadataSection from '@src/pages/Evaluator/overview/components/Metadata'
+import { formatDate } from '@src/utils/formatDates'
 
 describe('EvaluatorMetadataSection.cy.tsx', () => {
   it('should display populated metadata fields', () => {
@@ -15,13 +16,17 @@ describe('EvaluatorMetadataSection.cy.tsx', () => {
       potential_harm: '<p>Description of potential harm.</p>',
       alternate_explanation: '',
       crrg_reference:
-        '<p>Where to look in the CRRG:</p><ul><li>Page 2.3</li><li>Page 4.6</li></ul>'
+        '<p>Where to look in the CRRG:</p><ul><li>Page 2.3</li><li>Page 4.6</li></ul>',
+
+      interpret_fields_last_modified: '7/7/26'
     }
     cy.mount(<EvaluatorMetadataSection metadata={metadata} isAdmin />)
 
-    cy.findByTestId('metadata')
+    cy.get('.evaluate-expandable')
       .should('be.visible')
       .within(() => {
+        cy.get('.o-expandable__target').click()
+
         // Metadata fields with content should be output
         cy.contains('h4', 'Rationale').should('exist')
         cy.findByTestId('rationale')
@@ -41,6 +46,49 @@ describe('EvaluatorMetadataSection.cy.tsx', () => {
         // Metadata fields without content should be skipped
         cy.contains('h4', 'Alternate explanation').should('not.exist')
         cy.findByTestId('alternate_explanation').should('not.exist')
+
+        // Last updated date should be populated
+        cy.findByTestId('interpret-fields-last-modified-date')
+          .should('exist')
+          .and(
+            'contain',
+            formatDate(metadata.interpret_fields_last_modified, 'fullText')
+          )
+      })
+  })
+
+  it('should display no metadata note if no metadata fields populated', () => {
+    const metadata = {
+      id: 'test-eval',
+      description: 'Description of evaluator',
+      hits: 2222,
+      accounts_affected: 1111,
+      inconsistency_start: '1/1/24',
+      inconsistency_end: '1/1/25',
+      fields_used: ['acct_stat', 'acct_type'],
+      long_description: 'Long description of evaluator'
+    }
+    cy.mount(<EvaluatorMetadataSection metadata={metadata} isAdmin />)
+
+    cy.get('.evaluate-expandable')
+      .should('be.visible')
+      .within(() => {
+        cy.get('.o-expandable__target').click()
+
+        cy.findByTestId('no-metadata-message').should('exist')
+
+        // Last updated date should not be populated
+        cy.findByTestId('interpret-fields-last-modified-date').should('not.exist')
+
+        // Metadata fields without content should be skipped
+        cy.contains('h4', 'Alternate explanation').should('not.exist')
+        cy.findByTestId('alternate_explanation').should('not.exist')
+        cy.contains('h4', 'Rationale').should('not.exist')
+        cy.findByTestId('rationale').should('not.exist')
+        cy.contains('h4', 'CRRG reference').should('not.exist')
+        cy.findByTestId('crrg_reference').should('not.exist')
+        cy.contains('h4', 'Potential harm').should('not.exist')
+        cy.findByTestId('potential_harm').should('not.exist')
       })
   })
 
@@ -58,9 +106,12 @@ describe('EvaluatorMetadataSection.cy.tsx', () => {
       crrg_reference: 'Where to look in the CRRG.'
     }
     cy.mount(<EvaluatorMetadataSection metadata={metadata} isAdmin />)
-    cy.findByTestId('metadata-contribute-admin').should('be.visible')
-    cy.findByTestId('metadata-contribute').should('not.exist')
-    cy.findByTestId('no-metadata-contribute').should('not.exist')
+    cy.get('.evaluate-expandable').within(() => {
+      cy.get('.o-expandable__target').click()
+      cy.findByTestId('metadata-contribute-admin').should('be.visible')
+      cy.findByTestId('metadata-contribute').should('not.exist')
+      cy.findByTestId('no-metadata-contribute').should('not.exist')
+    })
   })
 
   it('should show no metadata call to action to non-admins', () => {
@@ -79,9 +130,12 @@ describe('EvaluatorMetadataSection.cy.tsx', () => {
       potential_harm: ''
     }
     cy.mount(<EvaluatorMetadataSection metadata={metadata} isAdmin={false} />)
-    cy.findByTestId('no-metadata-contribute').should('be.visible')
-    cy.findByTestId('metadata-contribute-admin').should('not.exist')
-    cy.findByTestId('metadata-contribute').should('not.exist')
+    cy.get('.evaluate-expandable').within(() => {
+      cy.get('.o-expandable__target').click()
+      cy.findByTestId('no-metadata-contribute').should('be.visible')
+      cy.findByTestId('metadata-contribute-admin').should('not.exist')
+      cy.findByTestId('metadata-contribute').should('not.exist')
+    })
   })
 
   it('should show metadata call to action to non-admins', () => {
@@ -101,8 +155,57 @@ describe('EvaluatorMetadataSection.cy.tsx', () => {
         '<p>Where to look in the CRRG:</p><ul><li>Page 2.3</li><li>Page 4.6</li></ul>'
     }
     cy.mount(<EvaluatorMetadataSection metadata={metadata} isAdmin={false} />)
-    cy.findByTestId('metadata-contribute').should('be.visible')
-    cy.findByTestId('metadata-contribute-admin').should('not.exist')
-    cy.findByTestId('no-metadata-contribute').should('not.exist')
+    cy.get('.evaluate-expandable').within(() => {
+      cy.get('.o-expandable__target').click()
+      cy.findByTestId('metadata-contribute').should('be.visible')
+      cy.findByTestId('metadata-contribute-admin').should('not.exist')
+      cy.findByTestId('no-metadata-contribute').should('not.exist')
+    })
+  })
+
+  it('should not show additional notes expandable if not populated', () => {
+    const metadata = {
+      id: 'test-eval',
+      description: 'Description of evaluator',
+      hits: 2222,
+      accounts_affected: 1111,
+      inconsistency_start: '1/1/24',
+      inconsistency_end: '1/1/25',
+      fields_used: ['acct_stat', 'acct_type'],
+      long_description: 'Long description of evaluator',
+      additional_notes: '',
+      additional_notes_last_modified: ''
+    }
+    cy.mount(<EvaluatorMetadataSection metadata={metadata} isAdmin={false} />)
+    cy.get('.additional-notes-expandable').should('not.exist')
+  })
+
+  it('should show additional notes expandable if populated', () => {
+    const metadata = {
+      id: 'test-eval',
+      description: 'Description of evaluator',
+      hits: 2222,
+      accounts_affected: 1111,
+      inconsistency_start: '1/1/24',
+      inconsistency_end: '1/1/25',
+      fields_used: ['acct_stat', 'acct_type'],
+      long_description: 'Long description of evaluator',
+      additional_notes: '<h4>Note category</h4><p>Lorem ipsum dolor</p>',
+      additional_notes_last_modified: '7/7/26'
+    }
+    cy.mount(<EvaluatorMetadataSection metadata={metadata} isAdmin={false} />)
+    cy.get('.additional-notes-expandable')
+      .should('be.visible')
+      .within(() => {
+        cy.findByTestId('additional-notes')
+          .should('exist')
+          .and('contain.html', metadata.additional_notes)
+        cy.findByTestId('additional-notes-last-modified-date')
+          .should('exist')
+          .and(
+            'contain',
+            formatDate(metadata.additional_notes_last_modified, 'fullText')
+          )
+      })
   })
 })

--- a/front-end/src/pages/Evaluator/overview/EvaluatorOverview.scss
+++ b/front-end/src/pages/Evaluator/overview/EvaluatorOverview.scss
@@ -36,3 +36,8 @@
 .metadata-expandable-content p {
   margin-bottom: math.div(math.div($grid_gutter-width, 3), $base-font-size-px) + em;
 }
+
+.last-modified-date,
+.contribute-instructions {
+  margin-top: math.div(20px, $base-font-size-px) + em;
+}

--- a/front-end/src/pages/Evaluator/overview/EvaluatorOverview.tsx
+++ b/front-end/src/pages/Evaluator/overview/EvaluatorOverview.tsx
@@ -39,12 +39,7 @@ export default function EvaluatorOverview({
                   }}></div>
               </div>
             </Accordion>
-            <Accordion header='How to evaluate these results'>
-              <EvaluatorMetadataSection
-                metadata={metadata}
-                isAdmin={user.is_admin}
-              />
-            </Accordion>
+            <EvaluatorMetadataSection metadata={metadata} isAdmin={user.is_admin} />
           </div>
         </div>
       </div>

--- a/front-end/src/pages/Evaluator/overview/components/Metadata.tsx
+++ b/front-end/src/pages/Evaluator/overview/components/Metadata.tsx
@@ -1,7 +1,8 @@
+import Accordion from '@src/components/Accordion/Accordion'
 import type EvaluatorMetadata from '@src/types/EvaluatorMetadata'
+import { formatDate } from '@src/utils/formatDates'
 import type { ReactElement } from 'react'
 export const adminUrlPrefix = import.meta.env.DEV ? 'http://localhost:8000' : ''
-
 /**
  * EvaluatorMetadata
  *
@@ -48,59 +49,100 @@ export default function EvaluatorMetadataSection({
   const hasMetadata = populatedFields.length > 0
 
   return (
-    <div className='metadata-expandable-content'>
-      {hasMetadata ? (
-        <div data-testid='metadata' className='metadata-section u-mb30'>
-          {populatedFields.map(field => (
-            <>
-              <h4>{explanatoryFields.get(field)}</h4>
-              <div
-                data-testid={field}
-                dangerouslySetInnerHTML={{
-                  __html: metadata[field as keyof EvaluatorMetadata] ?? ''
-                }}></div>
-            </>
-          ))}
-        </div>
-      ) : (
-        <div data-testid='no-metadata-message' className='u-mb15'>
-          <h4>Add additional context for this evaluator</h4>
-          <p>
-            Information contributed by users like you will help make the tool easier
-            to understand and more useful for everyone.
-          </p>
-        </div>
-      )}
-      {isAdmin === true ? (
-        <p data-testid='metadata-contribute-admin'>
-          {' '}
-          As a Metro2 admin, you can{' '}
-          <a
-            href={`${adminUrlPrefix}/admin/evaluate_m2/evaluatormetadata/${metadata.id}/change/`}
-            target='_blank'
-            rel='noreferrer'>
-            contribute additional context
-          </a>{' '}
-          directly to this evaluator.
-        </p>
-      ) : (
-        <>
+    <>
+      <Accordion
+        header='How to evaluate these results'
+        className='evaluate-expandable'>
+        <div className='metadata-expandable-content'>
           {hasMetadata ? (
-            <p data-testid='metadata-contribute'>
-              To contribute additional context for this evaluator, please contact a
-              Metro2 admin.
-            </p>
+            <div data-testid='metadata' className='metadata-section '>
+              {populatedFields.map(field => (
+                <>
+                  <h4>{explanatoryFields.get(field)}</h4>
+                  <div
+                    data-testid={field}
+                    dangerouslySetInnerHTML={{
+                      __html: metadata[field as keyof EvaluatorMetadata] ?? ''
+                    }}></div>
+                </>
+              ))}
+            </div>
           ) : (
-            <p className='u-mt15' data-testid='no-metadata-contribute'>
-              <a href='/guide/contribute' target='_blank' rel='noreferrer'>
-                See the user guide
-              </a>{' '}
-              for examples or contact a Metro 2 administrator to contribute
-              additional context for this evaluator.
-            </p>
+            <div data-testid='no-metadata-message' className='u-mb15'>
+              <h4>Add additional context for this evaluator</h4>
+              <p>
+                Information contributed by users like you will help make the tool
+                easier to understand and more useful for everyone.
+              </p>
+            </div>
           )}
-        </>
-      )}
-    </div>
+
+          <div className='contribute-instructions'>
+            {isAdmin === true ? (
+              <p data-testid='metadata-contribute-admin'>
+                {' '}
+                As a Metro2 admin, you can{' '}
+                <a
+                  href={`${adminUrlPrefix}/admin/evaluate_m2/evaluatormetadata/${metadata.id}/change/`}
+                  target='_blank'
+                  rel='noreferrer'>
+                  contribute additional context
+                </a>{' '}
+                directly to this evaluator.
+              </p>
+            ) : (
+              <>
+                {hasMetadata ? (
+                  <p data-testid='metadata-contribute '>
+                    To contribute additional context for this evaluator, please
+                    contact a Metro2 admin.
+                  </p>
+                ) : (
+                  <p data-testid='no-metadata-contribute'>
+                    <a href='/guide/contribute' target='_blank' rel='noreferrer'>
+                      See the user guide
+                    </a>{' '}
+                    for examples or contact a Metro 2 administrator to contribute
+                    additional context for this evaluator.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+          {metadata.interpret_fields_last_modified ? (
+            <p
+              data-testid='interpret-fields-last-modified'
+              className='last-modified-date'>
+              This data was last modified{' '}
+              <span data-testid='interpret-fields-last-modified-date'>
+                {formatDate(metadata.interpret_fields_last_modified, 'fullText')}.
+              </span>
+            </p>
+          ) : null}
+        </div>
+      </Accordion>
+      {metadata.additional_notes ? (
+        <Accordion header='Additional notes' className='additional-notes-expandable'>
+          <div className='metadata-expandable-content'>
+            <p
+              data-testid='additional-notes'
+              dangerouslySetInnerHTML={{
+                __html: metadata.additional_notes
+              }}
+            />
+            {metadata.additional_notes_last_modified ? (
+              <p
+                data-testid='additional-notes-last-modified'
+                className='last-modified-date'>
+                This data was last modified{' '}
+                <span data-testid='additional-notes-last-modified-date'>
+                  {formatDate(metadata.additional_notes_last_modified, 'fullText')}.
+                </span>
+              </p>
+            ) : null}
+          </div>
+        </Accordion>
+      ) : null}
+    </>
   )
 }

--- a/front-end/src/types/EvaluatorMetadata.ts
+++ b/front-end/src/types/EvaluatorMetadata.ts
@@ -13,4 +13,7 @@ export default interface EvaluatorMetadata {
   crrg_reference?: string | null
   potential_harm?: string | null
   rationale?: string | null
+  additional_notes?: string | null
+  interpret_fields_last_modified?: string | null
+  additional_notes_last_modified?: string | null
 }

--- a/front-end/src/utils/formatDates.spec.ts
+++ b/front-end/src/utils/formatDates.spec.ts
@@ -27,6 +27,10 @@ describe('formatDate', () => {
     expect(formatDate('2024-01-23', 'text')).toEqual('Jan 2024')
   })
 
+  it('returns a full text formatted date when passed a date string and format type', () => {
+    expect(formatDate('2024-01-23', 'fullText')).toEqual('January 23, 2024')
+  })
+
   it('returns empty string when passed a non-date-string value', () => {
     expect(formatDate(null)).toEqual('')
     expect(formatDate(UNDEFINED)).toEqual('')

--- a/front-end/src/utils/formatDates.ts
+++ b/front-end/src/utils/formatDates.ts
@@ -9,6 +9,12 @@ export const dateFormat = {
     month: 'short',
     year: 'numeric',
     timeZone: 'UTC'
+  },
+  fullText: {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC'
   }
 }
 
@@ -46,10 +52,13 @@ export const isDateString = (val: number | string | null | undefined): boolean =
  *
  *    - formatDate('2024-01-04', 'text')
  *      Returns: Jan 2024
+ *
+ *    - formatDate('2024-01-04', 'fullText')
+ *      Returns: January 4, 2024
  */
 export const formatDate = (
   val: number | string | null | undefined,
-  format: 'default' | 'text' = 'default'
+  format: 'default' | 'text' | 'fullText' = 'default'
 ): string => {
   if (!isDateString(val)) return ''
   return new Intl.DateTimeFormat(


### PR DESCRIPTION
Addresses internal ticket 1057.

Displays the fields added in https://github.com/cfpb/Metro2/pull/77 on the front end.

## Additions

- Add an h4 formatting option for the `additional_notes` field 
- Show the `Additional Notes` expandable when `additional_notes` field is populated
- Display last updated messages containing the `additional_notes_last_modified` and `interpret_fields_last_modified` values when they are populated
- Add new date formatting option for the last updated dates
- Add tests for new metadata output and new date format
- Update evaluator metadata type to reflect new fields

## Testing

1. PR checks should pass
2. To test manually, check out branch and navigate to an evaluator page.
    - [ ] Note that the `Additional notes` expandable is not displayed since there is no content for that metadata field.
    - [ ] Use the admin link in the `How to evaluate` expandable and add content for the additional notes and one other metadata field.
    - [ ] Note that the `Additional notes` expandable is displayed with the content added for that field.
    - [ ] Note that last modified dates are shown in both the `How to evaluate` and `Additional notes` expandables.

## Screenshots

<img width="880" height="855" alt="Screenshot 2026-07-22 at 4 10 59 PM" src="https://github.com/user-attachments/assets/5b4a206f-6f4d-49ef-ad88-f1e50fdb3720" />

