### PR TITLE
Add Django Debug Toolbar and ensure it renders

### DIFF
--- a/django/django_application/settings/base.py
+++ b/django/django_application/settings/base.py
@@ -66,8 +66,11 @@ MIDDLEWARE = [
 ROOT_URLCONF = 'django_application.urls'
 
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.AllowAny'
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.AllowAny",
+    ],
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
     ],
 }
 

--- a/django/django_application/settings/docker_compose.py
+++ b/django/django_application/settings/docker_compose.py
@@ -1,6 +1,29 @@
+import sys
 from .base import *
 
 DEBUG = True
+TESTING = "test" in sys.argv
+
+REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"].append(
+    'rest_framework.renderers.BrowsableAPIRenderer'
+)
+
+# If DEBUG is enabled and we're not running tests, add Django Debug Toolbar
+if DEBUG and not TESTING:
+    INSTALLED_APPS += ["debug_toolbar"]
+    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+    DEBUG_TOOLBAR_CONFIG = {
+        "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG,
+        "UPDATE_ON_FETCH": True,
+    }
+    DEBUG_TOOLBAR_PANELS = [
+        'debug_toolbar.panels.history.HistoryPanel',
+        'debug_toolbar.panels.timer.TimerPanel',
+        'debug_toolbar.panels.request.RequestPanel',
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.cache.CachePanel',
+        'debug_toolbar.panels.profiling.ProfilingPanel',
+    ]
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/django/django_application/urls.py
+++ b/django/django_application/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 """
 from contextlib import suppress
 
+from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import include, path, re_path
@@ -41,6 +42,13 @@ with suppress(ImproperlyConfigured):
     urlpatterns += [
         path('oauth2/', include('django_auth_adfs.urls')),
     ]
+
+# Add Django Debug Toolbar if it is installed
+if "debug_toolbar" in settings.INSTALLED_APPS:
+    from debug_toolbar.toolbar import debug_toolbar_urls
+
+    urlpatterns += debug_toolbar_urls()
+
 
 # All erroneous API calls to return 400: bad request
 urlpatterns.append(re_path(r'api(?:.*)?', app_views.bad_request_view ))

--- a/django/evaluate_m2/pagination.py
+++ b/django/evaluate_m2/pagination.py
@@ -1,7 +1,7 @@
 from django.conf import settings
-from django.http import JsonResponse
 
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
 
 
 class EvaluatorResultsPaginator(PageNumberPagination):
@@ -9,8 +9,7 @@ class EvaluatorResultsPaginator(PageNumberPagination):
     page_size_query_param = 'page_size'
 
     def get_paginated_response(self, data):
-        return JsonResponse({
+        return Response({
             "count": self.page.paginator.count,
             "hits": data
         })
-

--- a/django/evaluate_m2/tests/test_pagination.py
+++ b/django/evaluate_m2/tests/test_pagination.py
@@ -19,13 +19,8 @@ class TestPagination(SimpleTestCase):
         self.assertEqual(queryset, list(range(1, 21)))
 
         response = self.paginator.get_paginated_response(queryset)
-        self.assertJSONEqual(
-            str(response.content, encoding=response.charset),
-            {
-                "count": 100,
-                "hits": list(range(1, 21)),
-            },
-        )
+        self.assertEqual(response.data["count"], 100)
+        self.assertEqual(response.data["hits"], list(range(1, 21)))
 
     def test_paginated_response_with_page_number(self):
         request = Request(self.factory.get("/", {"page": 2}))
@@ -33,12 +28,5 @@ class TestPagination(SimpleTestCase):
         self.assertEqual(queryset, list(range(21, 41)))
 
         response = self.paginator.get_paginated_response(queryset)
-        self.assertJSONEqual(
-            str(response.content, encoding=response.charset),
-            {
-                "count": 100,
-                "hits": list(range(21, 41)),
-            },
-        )
-
-
+        self.assertEqual(response.data["count"], 100)
+        self.assertEqual(response.data["hits"], list(range(21, 41)))

--- a/django/evaluate_m2/views.py
+++ b/django/evaluate_m2/views.py
@@ -4,7 +4,7 @@ import logging
 from datetime import date
 
 from django.conf import settings
-from django.http import Http404, HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import Http404, HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_list_or_404
 
 import botocore
@@ -118,7 +118,7 @@ def account_summary_view(request, event_id, account_number):
         data = {'cons_acct_num': account_number,
                 'inconsistencies': evals_hit_uniq,
                 'account_activity': activities_serializer.data}
-        return JsonResponse(data)
+        return Response(data)
     except (
         Http404,
         Metro2Event.DoesNotExist,
@@ -143,7 +143,7 @@ def account_pii_view(request, event_id, account_number):
             cons_acct_num=account_number) \
                 .latest('activity_date')
         acct_holder_serializer = AccountHolderSerializer(latest_acct_activity)
-        return JsonResponse(acct_holder_serializer.data)
+        return Response(acct_holder_serializer.data)
     except (
         Metro2Event.DoesNotExist,
         AccountActivity.DoesNotExist
@@ -178,7 +178,7 @@ def events_view(request, event_id):
             'date_range_end': event.date_range_end,
             'evaluators': evaluator_metadata_serializer.data
         }
-        return JsonResponse(result)
+        return Response(result)
     except (
         Metro2Event.DoesNotExist,
         EvaluatorResultSummary.DoesNotExist
@@ -216,7 +216,7 @@ def fetch_json_results_from_s3(request, event_id, evaluator_id):
     try:
         file = s3.get_object(Bucket=settings.S3_BUCKET_NAME, Key=key)
         file_data = file['Body'].read().decode('utf-8')
-        return JsonResponse(json.loads(file_data))
+        return Response(json.loads(file_data))
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == "NoSuchKey":
             error = get_evaluate_m2_not_found_exception(

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.11.1
 coverage==7.13.5
 Django==5.2.14
+django-debug-toolbar==7.0.0
 psycopg==3.3.3
 psycopg-binary==3.3.3
 ruff==0.15.11


### PR DESCRIPTION
When running Metro2 with the local compose setup, include Django Debug Toolbar, and configure it to work through compose and show panels that are useful for API and SQL debugging.

One notable change here is that when running via compose I'm adding in Django Rest Framework's browsable API renderer and changing all views that previously rendered with `JsonResponse` to DRF's `Response` so that they get rendered through it. This results in templated URLs that have Django Debug Toolbar attached.


## Testing

1. Checkout this branch from the public repo
2. Run `docker compose up --build` to rebuild and bring up the containers
3. Visit an API URL (i.e. http://localhost:8000/api/events/1/) and observe that it's now rendered via Django Rest Framework's browsable API templates when viewing the endpoints directly, and observe the "DjDT" logo on the right side beside the scroll bar.
4. Click "DjDT" and view the debug panels, including "SQL", and see that SQL queries are shown with their timeline.
5. Visit the frontend, http://localhost:3000, and observe that everything still works (the frontend is still getting JSON responses)

## Notes

This doesn't directly add the DjDT panel to the frontend, because we can't with it running separately. However, our frontend query strings match up to what the API expects, so we should be able to easily match up front-end URLs to the API urls. Additionally, we can see the exact API request URL in browser tools.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
