### PR TITLE
Add an `/api/event/[event id]/account/` endpoint

### DIFF
--- a/django/evaluate_m2/filters.py
+++ b/django/evaluate_m2/filters.py
@@ -6,6 +6,7 @@ import django_filters.rest_framework
 from django_filters.constants import EMPTY_VALUES
 
 from evaluate_m2.models import EvaluatorResultMaterializedView
+from parse_m2.models import AccountActivity
 
 
 class NullInclusiveFilterMixin:
@@ -200,3 +201,21 @@ class EvaluatorResultFilterSet(django_filters.rest_framework.FilterSet):
             "smpa",
             "sort",
         ]
+
+
+class AccountListFilterSet(django_filters.rest_framework.FilterSet):
+    cons_acct_num = django_filters.BaseInFilter(
+        field_name="cons_acct_num",
+        lookup_expr="in"
+    )
+
+    class Meta:
+        model = AccountActivity
+        fields = ["cons_acct_num"]
+
+    # Require a specific list of accounts to filter, otherwise this
+    # filter will return an empty queryset.
+    def filter_queryset(self, queryset):
+        if not self.form.cleaned_data.get("cons_acct_num"):
+            return queryset.none()
+        return super().filter_queryset(queryset)

--- a/django/evaluate_m2/managers.py
+++ b/django/evaluate_m2/managers.py
@@ -20,7 +20,7 @@ class AccountActivityQuerySet(models.QuerySet):
             result_summary__event=event,
             acct_num=OuterRef("cons_acct_num"),
         ).order_by().values("acct_num").annotate(
-            n=Count("result_summary__evaluator_id", distinct=True),
+            n=Count("id"),
         ).values("n")[:1]
 
         return self.annotate(

--- a/django/evaluate_m2/managers.py
+++ b/django/evaluate_m2/managers.py
@@ -1,51 +1,59 @@
 from django.db import models
 from django.db.models import Count, IntegerField, OuterRef, Q, Subquery, Value
-from django.db.models.functions import Coalesce, TruncMonth
+from django.db.models.functions import Coalesce
 
 
 class AccountActivityQuerySet(models.QuerySet):
     def no_previous_bankruptcy_indicators(self):
-        return self.filter((
-                Q(previous_values__cons_info_ind_assoc__exact=[]) |
-                Q(previous_values__cons_info_ind_assoc__isnull=True)
-            ) & Q(previous_values__cons_info_ind='')
+        return self.filter(
+            (
+                Q(previous_values__cons_info_ind_assoc__exact=[])
+                | Q(previous_values__cons_info_ind_assoc__isnull=True)
+            )
+            & Q(previous_values__cons_info_ind="")
         )
 
-    def with_inconsistency_counts(self, event):
+    def with_hit_count(self, event):
         from evaluate_m2.models import EvaluatorResult
 
-        # Subquery for the number of inconsistencies (evaluators hit) for
-        # each account. This is just a count of hits.
-        subquery = EvaluatorResult.objects.filter(
-            result_summary__event=event,
-            acct_num=OuterRef("cons_acct_num"),
-        ).order_by().values("acct_num").annotate(
-            n=Count("id"),
-        ).values("n")[:1]
+        # Subquery for the number of evaluators hit for
+        # each account
+        subquery = (
+            EvaluatorResult.objects.filter(
+                result_summary__event=event,
+                acct_num=OuterRef("cons_acct_num"),
+            )
+            .order_by()
+            .values("acct_num")
+            .annotate(
+                n=Count("id"),
+            )
+            .values("n")[:1]
+        )
 
         return self.annotate(
-            total_inconsistencies=Coalesce(
+            total_hits=Coalesce(
                 Subquery(subquery, output_field=IntegerField()),
                 Value(0),
             ),
         )
 
-    def with_months_of_data(self, event):
-        # Subquery for the number of months of data. This counts **distinct**
-        # months, not the number of months in the total range.
-        # I.e. if there's data for Feb, March, and May, but not April, that's
-        # three months of data, not four.
-        subquery = self.model._default_manager.filter(
-            data_file__event=event,
-            cons_acct_num=OuterRef("cons_acct_num"),
-        ).order_by().annotate(
-            month=TruncMonth("activity_date"),
-        ).values("cons_acct_num").annotate(
-            n=Count("month", distinct=True),
-        ).values("n")[:1]
+    def with_record_count(self, event):
+        subquery = (
+            self.model._default_manager.filter(
+                data_file__event=event,
+                cons_acct_num=OuterRef("cons_acct_num"),
+            )
+            .order_by()
+            .values("cons_acct_num")
+            .annotate(
+                n=Count("id"),
+            )
+            .values("n")[:1]
+        )
 
         return self.annotate(
-            months_of_data=Coalesce(
+            total_records=Coalesce(
                 Subquery(subquery, output_field=IntegerField()),
                 Value(0),
             )

--- a/django/evaluate_m2/managers.py
+++ b/django/evaluate_m2/managers.py
@@ -1,5 +1,6 @@
 from django.db import models
-from django.db.models import Q
+from django.db.models import Count, IntegerField, OuterRef, Q, Subquery, Value
+from django.db.models.functions import Coalesce, TruncMonth
 
 
 class AccountActivityQuerySet(models.QuerySet):
@@ -9,3 +10,49 @@ class AccountActivityQuerySet(models.QuerySet):
                 Q(previous_values__cons_info_ind_assoc__isnull=True)
             ) & Q(previous_values__cons_info_ind='')
         )
+
+    def with_inconsistency_counts(self, event):
+        from evaluate_m2.models import EvaluatorResult
+
+        # Subquery for the number of inconsistencies (evaluators hit) for
+        # each account. This is just a count of hits.
+        subquery = EvaluatorResult.objects.filter(
+            result_summary__event=event,
+            acct_num=OuterRef("cons_acct_num"),
+        ).order_by().values("acct_num").annotate(
+            n=Count("result_summary__evaluator_id", distinct=True),
+        ).values("n")[:1]
+
+        return self.annotate(
+            total_inconsistencies=Coalesce(
+                Subquery(subquery, output_field=IntegerField()),
+                Value(0),
+            ),
+        )
+
+    def with_months_of_data(self, event):
+        # Subquery for the number of months of data. This counts **distinct**
+        # months, not the number of months in the total range.
+        # I.e. if there's data for Feb, March, and May, but not April, that's
+        # three months of data, not four.
+        subquery = self.model._default_manager.filter(
+            data_file__event=event,
+            cons_acct_num=OuterRef("cons_acct_num"),
+        ).order_by().annotate(
+            month=TruncMonth("activity_date"),
+        ).values("cons_acct_num").annotate(
+            n=Count("month", distinct=True),
+        ).values("n")[:1]
+
+        return self.annotate(
+            months_of_data=Coalesce(
+                Subquery(subquery, output_field=IntegerField()),
+                Value(0),
+            )
+        )
+
+    def distinct_accounts(self):
+        return self.order_by(
+            "cons_acct_num",
+            "-activity_date",
+        ).distinct("cons_acct_num")

--- a/django/evaluate_m2/serializers.py
+++ b/django/evaluate_m2/serializers.py
@@ -278,7 +278,6 @@ class AccountListSerializer(AccountActivitySerializer):
 
     class Meta(AccountActivitySerializer.Meta):
         default_fields = [
-            # list(AccountActivitySerializer.Meta.default_fields) + [
             "cons_acct_num",
             "port_type",
             "acct_type",

--- a/django/evaluate_m2/serializers.py
+++ b/django/evaluate_m2/serializers.py
@@ -277,7 +277,11 @@ class AccountListSerializer(AccountActivitySerializer):
     months_of_data = serializers.IntegerField(read_only=True)
 
     class Meta(AccountActivitySerializer.Meta):
-        default_fields = list(AccountActivitySerializer.Meta.default_fields) + [
+        default_fields = [
+            # list(AccountActivitySerializer.Meta.default_fields) + [
+            "cons_acct_num",
+            "port_type",
+            "acct_type",
             "total_inconsistencies",
             "months_of_data",
         ]

--- a/django/evaluate_m2/serializers.py
+++ b/django/evaluate_m2/serializers.py
@@ -11,6 +11,7 @@ from evaluate_m2.models import (
     EvaluatorResultMaterializedView,
     EvaluatorResultSummary,
 )
+from parse_m2.serializers import AccountActivitySerializer
 
 
 class EventsViewSerializer(serializers.ModelSerializer):
@@ -269,3 +270,14 @@ class EvaluatorResultSerializer(serializers.ModelSerializer):
     class Meta:
         model = EvaluatorResultMaterializedView
         fields = '__all__'
+
+
+class AccountListSerializer(AccountActivitySerializer):
+    total_inconsistencies = serializers.IntegerField(read_only=True)
+    months_of_data = serializers.IntegerField(read_only=True)
+
+    class Meta(AccountActivitySerializer.Meta):
+        default_fields = list(AccountActivitySerializer.Meta.default_fields) + [
+            "total_inconsistencies",
+            "months_of_data",
+        ]

--- a/django/evaluate_m2/serializers.py
+++ b/django/evaluate_m2/serializers.py
@@ -273,14 +273,14 @@ class EvaluatorResultSerializer(serializers.ModelSerializer):
 
 
 class AccountListSerializer(AccountActivitySerializer):
-    total_inconsistencies = serializers.IntegerField(read_only=True)
-    months_of_data = serializers.IntegerField(read_only=True)
+    total_hits = serializers.IntegerField(read_only=True)
+    total_records = serializers.IntegerField(read_only=True)
 
     class Meta(AccountActivitySerializer.Meta):
         default_fields = [
             "cons_acct_num",
             "port_type",
             "acct_type",
-            "total_inconsistencies",
-            "months_of_data",
+            "total_hits",
+            "total_records",
         ]

--- a/django/evaluate_m2/tests/evaluator_test_helper.py
+++ b/django/evaluate_m2/tests/evaluator_test_helper.py
@@ -1,6 +1,11 @@
 from datetime import date
 
 from evaluate_m2.evaluate import evaluator
+from evaluate_m2.models import (
+    EvaluatorMetadata,
+    EvaluatorResult,
+    EvaluatorResultSummary,
+)
 from parse_m2.models import J1, J2, K2, K4, L1, AccountActivity, M2DataFile, Metro2Event
 
 
@@ -106,6 +111,7 @@ def acct_record(file: M2DataFile, custom_values: dict) -> AccountActivity:
     acct_activity.save()
     return acct_activity
 
+
 def k2_record(custom_values: dict):
     """
     Returns a K2 record for use in tests, using the values
@@ -130,6 +136,7 @@ def k2_record(custom_values: dict):
     )
     k2.save()
     return k2
+
 
 def k4_record(custom_values: dict):
     """
@@ -160,6 +167,7 @@ def k4_record(custom_values: dict):
     k4.save()
     return k4
 
+
 def l1_record(custom_values: dict):
     """
     Returns a L1 record for use in tests, using the values
@@ -187,6 +195,7 @@ def l1_record(custom_values: dict):
     l1.save()
     return l1
 
+
 def create_bulk_acct_record(file: M2DataFile, value_list: dict, size: int):
     """
     Returns a list of AccountActivity records for use in tests, using the values
@@ -207,6 +216,7 @@ def create_bulk_acct_record(file: M2DataFile, value_list: dict, size: int):
         acct_activity = acct_record(file, custom_values[i])
         account_activities.append(acct_activity)
     return account_activities
+
 
 def create_bulk_JSegments(j_type: str, value_list: dict, size: int):
     """
@@ -238,6 +248,39 @@ def create_bulk_JSegments(j_type: str, value_list: dict, size: int):
         return J1.objects.bulk_create(j_segments)
     else:
         return J2.objects.bulk_create(j_segments)
+
+
+def evaluator_result_record(
+    event: Metro2Event,
+    evaluator_id: str,
+    source_record: AccountActivity
+) -> EvaluatorResult:
+    """
+    Returns an EvaluatorResult for use in tests, creating the parent
+    EvaluatorResultSummary (one per evaluator/event) as needed.
+
+    Inputs:
+    - event: the Metro2Event the result belongs to
+    - evaluator_id: id for the EvaluatorMetadata (created if absent)
+    - source_record: the AccountActivity the result points to
+    """
+    evaluator, _ = EvaluatorMetadata.objects.get_or_create(
+        id=evaluator_id
+    )
+    result_summary, _ = EvaluatorResultSummary.objects.get_or_create(
+        event=event,
+        evaluator=evaluator,
+        defaults={
+            "hits": 0,
+            "sample_ids": []
+        }
+    )
+    return EvaluatorResult.objects.create(
+        result_summary=result_summary,
+        acct_num=source_record.cons_acct_num,
+        source_record=source_record,
+        date=source_record.activity_date,
+    )
 
 
 class EvaluatorTestHelper:

--- a/django/evaluate_m2/tests/test_managers.py
+++ b/django/evaluate_m2/tests/test_managers.py
@@ -153,7 +153,7 @@ class AccountActivityQuerySetAnnotationsTest(TestCase):
 
         qs = AccountActivity.objects.with_inconsistency_counts(self.event)
         query_acct = qs.filter(cons_acct_num=acct1.cons_acct_num).first()
-        self.assertEqual(query_acct.total_inconsistencies, 1)
+        self.assertEqual(query_acct.total_inconsistencies, 2)
 
     def test_months_of_data(self):
         acct_record(

--- a/django/evaluate_m2/tests/test_managers.py
+++ b/django/evaluate_m2/tests/test_managers.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from django.test import TestCase
 
-from evaluate_m2.tests.evaluator_test_helper import acct_record
+from evaluate_m2.tests.evaluator_test_helper import acct_record, evaluator_result_record
 from parse_m2.models import AccountActivity, M2DataFile, Metro2Event
 
 
@@ -110,3 +110,75 @@ class AccountActivityQuerySetTest(TestCase):
 
         result = AccountActivity.objects.no_previous_bankruptcy_indicators().count()
         self.assertEqual(result, 0)
+
+
+class AccountActivityQuerySetAnnotationsTest(TestCase):
+    def setUp(self) -> None:
+        self.event = Metro2Event.objects.create(name = "test")
+        self.file = M2DataFile.objects.create(event=self.event, file_name="test")
+
+    def test_inconsistency_counts(self):
+        acct = acct_record(
+            self.file, {
+                "id":"1",
+                "activity_date": date(2022, 5, 31),
+                "cons_acct_num": "0032",
+            }
+        )
+        evaluator_result_record(self.event, "Sample-1", acct)
+        evaluator_result_record(self.event, "Sample-2", acct)
+
+        qs = AccountActivity.objects.with_inconsistency_counts(self.event)
+        query_acct = qs.filter(cons_acct_num=acct.cons_acct_num).first()
+        self.assertEqual(query_acct.total_inconsistencies, 2)
+
+    def test_inconsistency_counts_same_eval(self):
+        acct1 = acct_record(
+            self.file, {
+                "id":"1",
+                "activity_date": date(2022, 5, 31),
+                "cons_acct_num": "0032",
+            }
+        )
+        acct2 = acct_record(
+            self.file, {
+                "id":"2",
+                "activity_date": date(2022, 6, 30),
+                "cons_acct_num": "0032",
+            }
+        )
+        # One hit across two months
+        evaluator_result_record(self.event, "Sample-1", acct1)
+        evaluator_result_record(self.event, "Sample-1", acct2)
+
+        qs = AccountActivity.objects.with_inconsistency_counts(self.event)
+        query_acct = qs.filter(cons_acct_num=acct1.cons_acct_num).first()
+        self.assertEqual(query_acct.total_inconsistencies, 1)
+
+    def test_months_of_data(self):
+        acct_record(
+            self.file, {
+                "id":"1",
+                "activity_date": date(2022, 6, 5),
+                "cons_acct_num": "0032",
+            }
+        )
+        acct_record(
+            self.file, {
+                "id":"2",
+                "activity_date": date(2022, 6, 20),
+                "cons_acct_num": "0032",
+            }
+        )
+        acct_record(
+            self.file, {
+                "id":"3",
+                "activity_date": date(2022, 8, 1),
+                "cons_acct_num": "0032",
+            }
+        )
+
+        qs = AccountActivity.objects.with_months_of_data(self.event)
+        query_acct = qs.filter(cons_acct_num="0032").first()
+        # June + August
+        self.assertEqual(query_acct.months_of_data, 2)

--- a/django/evaluate_m2/tests/test_managers.py
+++ b/django/evaluate_m2/tests/test_managers.py
@@ -8,105 +8,135 @@ from parse_m2.models import AccountActivity, M2DataFile, Metro2Event
 
 class AccountActivityQuerySetTest(TestCase):
     def setUp(self) -> None:
-        event = Metro2Event.objects.create(name = "test")
+        event = Metro2Event.objects.create(name="test")
         self.prev_file = M2DataFile.objects.create(event=event, file_name="test1")
         self.file = M2DataFile.objects.create(event=event, file_name="test")
 
     def test_base_has_no_previous_bankruptcy_indicators(self):
-        prior_acct = acct_record(self.prev_file, {
-            "id":"1",
-            "activity_date": date(2022, 5, 31),
-            "cons_acct_num": "0032",
-            "cons_info_ind": "",
-            "previous_values":None
-            })
-        acct_record(self.file, {
-            "id":"2",
-            "cons_acct_num": "0032",
-            "activity_date": date(2022, 6, 30),
-            "cons_info_ind": "a",
-            "previous_values":prior_acct
-            })
+        prior_acct = acct_record(
+            self.prev_file,
+            {
+                "id": "1",
+                "activity_date": date(2022, 5, 31),
+                "cons_acct_num": "0032",
+                "cons_info_ind": "",
+                "previous_values": None,
+            },
+        )
+        acct_record(
+            self.file,
+            {
+                "id": "2",
+                "cons_acct_num": "0032",
+                "activity_date": date(2022, 6, 30),
+                "cons_info_ind": "a",
+                "previous_values": prior_acct,
+            },
+        )
         result = AccountActivity.objects.no_previous_bankruptcy_indicators().count()
         self.assertEqual(result, 1)
 
     def test_base_has_bankruptcy_indicators(self):
-        prior_acct = acct_record(self.prev_file, {
-            "id":"1",
-            "activity_date": date(2022, 5, 31),
-            "cons_acct_num": "0032",
-            "cons_info_ind": "a",
-            "previous_values":None
-            })
-        acct_record(self.file, {
-            "id":"2",
-            "cons_acct_num": "0032",
-            "activity_date": date(2022, 6, 30),
-            "cons_info_ind": "a",
-            "previous_values":prior_acct
-            })
+        prior_acct = acct_record(
+            self.prev_file,
+            {
+                "id": "1",
+                "activity_date": date(2022, 5, 31),
+                "cons_acct_num": "0032",
+                "cons_info_ind": "a",
+                "previous_values": None,
+            },
+        )
+        acct_record(
+            self.file,
+            {
+                "id": "2",
+                "cons_acct_num": "0032",
+                "activity_date": date(2022, 6, 30),
+                "cons_info_ind": "a",
+                "previous_values": prior_acct,
+            },
+        )
         result = AccountActivity.objects.no_previous_bankruptcy_indicators().count()
         self.assertEqual(result, 0)
 
     def test_j_segment_has_no_previous_bankruptcy_indicators(self):
-        prior_acct = acct_record(self.prev_file, {
-            "id":"1",
-            "activity_date": date(2022, 5, 31),
-            "cons_acct_num": "0032",
-            "cons_info_ind": "",
-            "previous_values":None,
-            "cons_info_ind_assoc": []
-            })
+        prior_acct = acct_record(
+            self.prev_file,
+            {
+                "id": "1",
+                "activity_date": date(2022, 5, 31),
+                "cons_acct_num": "0032",
+                "cons_info_ind": "",
+                "previous_values": None,
+                "cons_info_ind_assoc": [],
+            },
+        )
 
-        acct_record(self.file, {
-            "id":"2",
-            "cons_acct_num": "0032",
-            "activity_date": date(2022, 6, 30),
-            "cons_info_ind": "a",
-            "previous_values":prior_acct
-            })
+        acct_record(
+            self.file,
+            {
+                "id": "2",
+                "cons_acct_num": "0032",
+                "activity_date": date(2022, 6, 30),
+                "cons_info_ind": "a",
+                "previous_values": prior_acct,
+            },
+        )
 
         result = AccountActivity.objects.no_previous_bankruptcy_indicators().count()
         self.assertEqual(result, 1)
 
     def test_j1_has_one_previous_bankruptcy_indicators(self):
-        prior_acct = acct_record(self.prev_file, {
-            "id":"1",
-            "activity_date": date(2022, 5, 31),
-            "cons_acct_num": "0032",
-            "cons_info_ind": "",
-            "previous_values":None,
-            "cons_info_ind_assoc": ["x",""]
-            })
+        prior_acct = acct_record(
+            self.prev_file,
+            {
+                "id": "1",
+                "activity_date": date(2022, 5, 31),
+                "cons_acct_num": "0032",
+                "cons_info_ind": "",
+                "previous_values": None,
+                "cons_info_ind_assoc": ["x", ""],
+            },
+        )
 
-        acct_record(self.file, {
-            "id":"2",
-            "cons_acct_num": "0032",
-            "activity_date": date(2022, 6, 30),
-            "cons_info_ind": "a",
-            "previous_values":prior_acct
-            })
+        acct_record(
+            self.file,
+            {
+                "id": "2",
+                "cons_acct_num": "0032",
+                "activity_date": date(2022, 6, 30),
+                "cons_info_ind": "a",
+                "previous_values": prior_acct,
+            },
+        )
 
         result = AccountActivity.objects.no_previous_bankruptcy_indicators().count()
         self.assertEqual(result, 0)
 
     def test_j1_has_previous_bankruptcy_indicators(self):
-        prior_acct = acct_record(self.prev_file, {
-            "id":"1",
-            "activity_date": date(2022, 5, 31),
-            "cons_acct_num": "0032",
-            "cons_info_ind": "",
-            "previous_values":None,
-            "cons_info_ind_assoc": ["X"]
-            })
+        prior_acct = acct_record(
+            self.prev_file,
+            {
+                "id": "1",
+                "activity_date": date(2022, 5, 31),
+                "cons_acct_num": "0032",
+                "cons_info_ind": "",
+                "previous_values": None,
+                "cons_info_ind_assoc": ["X"],
+            },
+        )
 
-        acct_record(self.file, {
-            "id":"2",
-            "cons_acct_num": "0032",
-            "activity_date": date(2022, 6, 30),
-            "cons_info_ind": "a",
-            "previous_values":prior_acct
-            })
+        acct_record(
+            self.file,
+            {
+                "id": "2",
+                "cons_acct_num": "0032",
+                "activity_date": date(2022, 6, 30),
+                "cons_info_ind": "a",
+                "previous_values": prior_acct,
+            },
+        )
 
         result = AccountActivity.objects.no_previous_bankruptcy_indicators().count()
         self.assertEqual(result, 0)
@@ -114,71 +144,77 @@ class AccountActivityQuerySetTest(TestCase):
 
 class AccountActivityQuerySetAnnotationsTest(TestCase):
     def setUp(self) -> None:
-        self.event = Metro2Event.objects.create(name = "test")
+        self.event = Metro2Event.objects.create(name="test")
         self.file = M2DataFile.objects.create(event=self.event, file_name="test")
 
     def test_inconsistency_counts(self):
         acct = acct_record(
-            self.file, {
-                "id":"1",
+            self.file,
+            {
+                "id": "1",
                 "activity_date": date(2022, 5, 31),
                 "cons_acct_num": "0032",
-            }
+            },
         )
         evaluator_result_record(self.event, "Sample-1", acct)
         evaluator_result_record(self.event, "Sample-2", acct)
 
-        qs = AccountActivity.objects.with_inconsistency_counts(self.event)
+        qs = AccountActivity.objects.with_hit_count(self.event)
         query_acct = qs.filter(cons_acct_num=acct.cons_acct_num).first()
-        self.assertEqual(query_acct.total_inconsistencies, 2)
+        self.assertEqual(query_acct.total_hits, 2)
 
     def test_inconsistency_counts_same_eval(self):
         acct1 = acct_record(
-            self.file, {
-                "id":"1",
+            self.file,
+            {
+                "id": "1",
                 "activity_date": date(2022, 5, 31),
                 "cons_acct_num": "0032",
-            }
+            },
         )
         acct2 = acct_record(
-            self.file, {
-                "id":"2",
+            self.file,
+            {
+                "id": "2",
                 "activity_date": date(2022, 6, 30),
                 "cons_acct_num": "0032",
-            }
+            },
         )
         # One hit across two months
         evaluator_result_record(self.event, "Sample-1", acct1)
         evaluator_result_record(self.event, "Sample-1", acct2)
 
-        qs = AccountActivity.objects.with_inconsistency_counts(self.event)
+        qs = AccountActivity.objects.with_hit_count(self.event)
         query_acct = qs.filter(cons_acct_num=acct1.cons_acct_num).first()
-        self.assertEqual(query_acct.total_inconsistencies, 2)
+        self.assertEqual(query_acct.total_hits, 2)
 
-    def test_months_of_data(self):
+    def test_record_counts(self):
         acct_record(
-            self.file, {
-                "id":"1",
+            self.file,
+            {
+                "id": "1",
                 "activity_date": date(2022, 6, 5),
                 "cons_acct_num": "0032",
-            }
+            },
         )
         acct_record(
-            self.file, {
-                "id":"2",
+            self.file,
+            {
+                "id": "2",
                 "activity_date": date(2022, 6, 20),
                 "cons_acct_num": "0032",
-            }
+            },
         )
         acct_record(
-            self.file, {
-                "id":"3",
+            self.file,
+            {
+                "id": "3",
                 "activity_date": date(2022, 8, 1),
                 "cons_acct_num": "0032",
-            }
+            },
         )
 
-        qs = AccountActivity.objects.with_months_of_data(self.event)
+        qs = AccountActivity.objects.with_record_count(self.event)
         query_acct = qs.filter(cons_acct_num="0032").first()
         # June + August
-        self.assertEqual(query_acct.months_of_data, 2)
+        self.assertEqual(query_acct.total_records, 3)

--- a/django/evaluate_m2/tests/test_views.py
+++ b/django/evaluate_m2/tests/test_views.py
@@ -328,16 +328,16 @@ class EvaluateViewsTestCase(TestCase):
             {
                 "acct_type": "",
                 "cons_acct_num": "0032",
-                "months_of_data": 1,
+                "total_records": 1,
                 "port_type": "A",
-                "total_inconsistencies": 2
+                "total_hits": 2
             },
             {
                 "acct_type": "",
                 "cons_acct_num": "0033",
-                "months_of_data": 1,
+                "total_records": 1,
                 "port_type": "A",
-                "total_inconsistencies": 1
+                "total_hits": 1
             }
         ]
         response = self.client.get("/api/events/1/account/?cons_acct_num=0033,0032")

--- a/django/evaluate_m2/tests/test_views.py
+++ b/django/evaluate_m2/tests/test_views.py
@@ -311,6 +311,43 @@ class EvaluateViewsTestCase(TestCase):
             status_code=404)
 
     ########################################
+    # Tests for Account list view API endpoint
+    def test_account_list_view_no_acct_num(self):
+        self.create_activity_data()
+        expected = []
+        response = self.client.get("/api/events/1/account/")
+
+        # the response should be a JSON
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+        self.assertEqual(response.json(), expected)
+
+    def test_account_list_view(self):
+        self.create_activity_data()
+        expected = [
+            {
+                "acct_type": "",
+                "cons_acct_num": "0032",
+                "months_of_data": 1,
+                "port_type": "A",
+                "total_inconsistencies": 2
+            },
+            {
+                "acct_type": "",
+                "cons_acct_num": "0033",
+                "months_of_data": 1,
+                "port_type": "A",
+                "total_inconsistencies": 1
+            }
+        ]
+        response = self.client.get("/api/events/1/account/?cons_acct_num=0033,0032")
+
+        # the response should be a JSON
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+        self.assertEqual(response.json(), expected)
+
+    ########################################
     # Tests for Account Summary view API endpoint
     def test_account_summary_view_single_results(self):
         self.create_activity_data()

--- a/django/evaluate_m2/urls.py
+++ b/django/evaluate_m2/urls.py
@@ -9,9 +9,11 @@ urlpatterns = [
          eval_views.download_evaluator_results_csv),
     path('<int:event_id>/evaluator/<str:evaluator_id>/',
          eval_views.EvaluatorResultsView().as_view()),
+    path('<int:event_id>/account/',
+        eval_views.AccountsListView().as_view()),
     path('<int:event_id>/account/<str:account_number>/',
-         eval_views.account_summary_view),
+        eval_views.account_summary_view),
     path('<int:event_id>/account/<str:account_number>/account_holder/',
-         eval_views.account_pii_view),
+        eval_views.account_pii_view),
      path('<int:event_id>/', eval_views.events_view),
 ]

--- a/django/evaluate_m2/views.py
+++ b/django/evaluate_m2/views.py
@@ -43,13 +43,13 @@ from parse_m2.models import AccountActivity, Metro2Event
 from parse_m2.serializers import AccountActivitySerializer, AccountHolderSerializer
 
 
-@api_view(('GET',))
+@api_view(("GET",))
 def download_evaluator_metadata_csv(request):
     # Documentation on returning CSV: https://docs.djangoproject.com/en/4.2/howto/outputting-csv/
     filename = f"evaluator-metadata-{date.today()}.csv"
     response = HttpResponse(
         content_type="text/csv",
-        headers={"Content-Disposition": f"attachment; filename={filename}"}
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
     )
 
     eval_metadata_serializer = EvaluatorMetadataSerializer(
@@ -67,17 +67,18 @@ def download_evaluator_metadata_csv(request):
     return response
 
 
-@api_view(('GET',))
+@api_view(("GET",))
 def download_evaluator_results_csv(request, event_id, evaluator_id):
-    logger = logging.getLogger('views.download_evaluator_results_csv')
+    logger = logging.getLogger("views.download_evaluator_results_csv")
     try:
         event = Metro2Event.objects.get(id=event_id)
         evaluator = EvaluatorMetadata.objects.get(id=evaluator_id)
         eval_result_summary = EvaluatorResultSummary.objects.get(
-            event=event, evaluator=evaluator)
+            event=event, evaluator=evaluator
+        )
 
         if not has_permissions_for_request(request, event):
-            return HttpResponse('Unauthorized', status=401)
+            return HttpResponse("Unauthorized", status=401)
 
         if settings.S3_ENABLED:
             return fetch_csv_results_from_s3(request, event_id, evaluator_id)
@@ -87,123 +88,124 @@ def download_evaluator_results_csv(request, event_id, evaluator_id):
             filename = f"{event.name}_{evaluator.id}.csv"
             response = HttpResponse(
                 content_type="text/csv",
-                headers={"Content-Disposition": f"attachment; filename={filename}"}
+                headers={"Content-Disposition": f"attachment; filename={filename}"},
             )
             return upload_utils.generate_full_csv(eval_result_summary, response)
     except (
         Metro2Event.DoesNotExist,
         EvaluatorMetadata.DoesNotExist,
-        EvaluatorResultSummary.DoesNotExist
+        EvaluatorResultSummary.DoesNotExist,
     ) as e:
         error = get_evaluate_m2_not_found_exception(
-            str(e), event_id, evaluator_id, request.path)
-        logger.error(error['message'])
+            str(e), event_id, evaluator_id, request.path
+        )
+        logger.error(error["message"])
         return Response(error, status=status.HTTP_404_NOT_FOUND)
 
 
-@api_view(('GET',))
+@api_view(("GET",))
 def account_summary_view(request, event_id, account_number):
-    logger = logging.getLogger('views.account_summary_view')
+    logger = logging.getLogger("views.account_summary_view")
     try:
         event = Metro2Event.objects.get(id=event_id)
         if not has_permissions_for_request(request, event):
-            return HttpResponse('Unauthorized', status=401)
-        event_activities=get_list_or_404(
-            event.get_all_account_activity().filter(
-                cons_acct_num=account_number).order_by('activity_date') \
-                .select_related('k2', 'k4', 'l1')
-            )
+            return HttpResponse("Unauthorized", status=401)
+        event_activities = get_list_or_404(
+            event.get_all_account_activity()
+            .filter(cons_acct_num=account_number)
+            .order_by("activity_date")
+            .select_related("k2", "k4", "l1")
+        )
         if not event_activities:
             raise Http404()
         activities_serializer = AccountActivitySerializer(event_activities, many=True)
 
         eval_results = EvaluatorResult.objects.filter(
-            acct_num=account_number,
-            result_summary__event=event) \
-            .select_related('result_summary')
+            acct_num=account_number, result_summary__event=event
+        ).select_related("result_summary")
         evals_hit = [e.result_summary.evaluator_id for e in eval_results]
         evals_hit_uniq = sorted(list(set(evals_hit)))
 
-        data = {'cons_acct_num': account_number,
-                'inconsistencies': evals_hit_uniq,
-                'account_activity': activities_serializer.data}
+        data = {
+            "cons_acct_num": account_number,
+            "inconsistencies": evals_hit_uniq,
+            "account_activity": activities_serializer.data,
+        }
         return Response(data)
     except (
         Http404,
         Metro2Event.DoesNotExist,
         EvaluatorMetadata.DoesNotExist,
         EvaluatorResult.DoesNotExist,
-        AccountActivity.DoesNotExist
+        AccountActivity.DoesNotExist,
     ) as e:
         error = get_evaluate_m2_not_found_exception(
-            str(e), event_id, None, request.path, account_number)
-        logger.error(error['message'])
+            str(e), event_id, None, request.path, account_number
+        )
+        logger.error(error["message"])
         return Response(error, status=status.HTTP_404_NOT_FOUND)
 
 
-@api_view(('GET',))
+@api_view(("GET",))
 def account_pii_view(request, event_id, account_number):
-    logger = logging.getLogger('views.account_pii_view')
+    logger = logging.getLogger("views.account_pii_view")
     try:
         event = Metro2Event.objects.get(id=event_id)
         if not has_permissions_for_request(request, event):
-            return HttpResponse('Unauthorized', status=401)
+            return HttpResponse("Unauthorized", status=401)
         latest_acct_activity = AccountActivity.objects.filter(
-            data_file__event=event,
-            cons_acct_num=account_number) \
-                .latest('activity_date')
+            data_file__event=event, cons_acct_num=account_number
+        ).latest("activity_date")
         acct_holder_serializer = AccountHolderSerializer(latest_acct_activity)
         return Response(acct_holder_serializer.data)
-    except (
-        Metro2Event.DoesNotExist,
-        AccountActivity.DoesNotExist
-    ) as e:
+    except (Metro2Event.DoesNotExist, AccountActivity.DoesNotExist) as e:
         error = get_evaluate_m2_not_found_exception(
-            str(e), event_id, None, request.path, account_number)
-        logger.error(error['message'])
+            str(e), event_id, None, request.path, account_number
+        )
+        logger.error(error["message"])
         return Response(error, status=status.HTTP_404_NOT_FOUND)
 
 
 @api_view()
 def events_view(request, event_id):
-    logger = logging.getLogger('views.evaluator_results_view')
+    logger = logging.getLogger("views.evaluator_results_view")
     try:
         event = Metro2Event.objects.get(id=event_id)
         if not has_permissions_for_request(request, event):
-            return HttpResponse('Unauthorized', status=401)
+            return HttpResponse("Unauthorized", status=401)
 
-        eval_result_summaries = EvaluatorResultSummary.objects \
-                .filter(event=event, hits__gt=0) \
-                .select_related('evaluator') \
-                .order_by('evaluator__id')
+        eval_result_summaries = (
+            EvaluatorResultSummary.objects.filter(event=event, hits__gt=0)
+            .select_related("evaluator")
+            .order_by("evaluator__id")
+        )
         evaluator_metadata_serializer = EventsViewSerializer(
-            eval_result_summaries, many=True, context={'event': event})
+            eval_result_summaries, many=True, context={"event": event}
+        )
         result = {
-            'id': event.id,
-            'name': event.name,
-            'portfolio': event.portfolio,
-            'eid_or_matter_num': event.eid_or_matter_num,
-            'other_descriptor': event.other_descriptor,
-            'directory': event.directory,
-            'date_range_start': event.date_range_start,
-            'date_range_end': event.date_range_end,
-            'evaluators': evaluator_metadata_serializer.data
+            "id": event.id,
+            "name": event.name,
+            "portfolio": event.portfolio,
+            "eid_or_matter_num": event.eid_or_matter_num,
+            "other_descriptor": event.other_descriptor,
+            "directory": event.directory,
+            "date_range_start": event.date_range_start,
+            "date_range_end": event.date_range_end,
+            "evaluators": evaluator_metadata_serializer.data,
         }
         return Response(result)
-    except (
-        Metro2Event.DoesNotExist,
-        EvaluatorResultSummary.DoesNotExist
-    ) as e:
+    except (Metro2Event.DoesNotExist, EvaluatorResultSummary.DoesNotExist) as e:
         error = get_evaluate_m2_not_found_exception(
-            str(e), event_id, None, request.path)
-        logger.error(error['message'])
+            str(e), event_id, None, request.path
+        )
+        logger.error(error["message"])
         return Response(error, status=status.HTTP_404_NOT_FOUND)
 
 
 ###########################################
 ## Helper methods for eval results when S3_ENABLED == True
 def fetch_csv_results_from_s3(request, event_id, evaluator_id):
-    logger = logging.getLogger('views.fetch_csv_results_from_s3')
+    logger = logging.getLogger("views.fetch_csv_results_from_s3")
     filename = upload_utils.s3_filename(evaluator_id, "csv")
     key = upload_utils.s3_bucket_key(event_id, evaluator_id, "csv")
     try:
@@ -215,26 +217,36 @@ def fetch_csv_results_from_s3(request, event_id, evaluator_id):
         response["Content-Disposition"] = f"attachment; filename={filename}"
         return response
     except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == "NoSuchKey":
+        if e.response["Error"]["Code"] == "NoSuchKey":
             error = get_evaluate_m2_not_found_exception(
-            e.response['Error']['Message'], event_id, evaluator_id, request.path, None)
-            logger.error(error['message'])
+                e.response["Error"]["Message"],
+                event_id,
+                evaluator_id,
+                request.path,
+                None,
+            )
+            logger.error(error["message"])
             return Response(error, status=status.HTTP_404_NOT_FOUND)
 
 
 def fetch_json_results_from_s3(request, event_id, evaluator_id):
-    logger = logging.getLogger('views.fetch_json_results_from_s3')
+    logger = logging.getLogger("views.fetch_json_results_from_s3")
     s3 = s3_session()
     key = upload_utils.s3_bucket_key(event_id, evaluator_id, "json")
     try:
         file = s3.get_object(Bucket=settings.S3_BUCKET_NAME, Key=key)
-        file_data = file['Body'].read().decode('utf-8')
+        file_data = file["Body"].read().decode("utf-8")
         return Response(json.loads(file_data))
     except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == "NoSuchKey":
+        if e.response["Error"]["Code"] == "NoSuchKey":
             error = get_evaluate_m2_not_found_exception(
-            e.response['Error']['Message'], event_id, evaluator_id, request.path, None)
-            logger.error(error['message'])
+                e.response["Error"]["Message"],
+                event_id,
+                evaluator_id,
+                request.path,
+                None,
+            )
+            logger.error(error["message"])
             return Response(error, status=status.HTTP_404_NOT_FOUND)
 
 
@@ -260,18 +272,18 @@ class EvaluatorResultsView(generics.ListAPIView):
         try:
             return super().get(request, *args, **kwargs)
         except (
-                Metro2Event.DoesNotExist,
-                EvaluatorMetadata.DoesNotExist,
-                EvaluatorResultSummary.DoesNotExist
-            ) as e:
-            logger = logging.getLogger('views.download_evaluator_results_csv')
+            Metro2Event.DoesNotExist,
+            EvaluatorMetadata.DoesNotExist,
+            EvaluatorResultSummary.DoesNotExist,
+        ) as e:
+            logger = logging.getLogger("views.download_evaluator_results_csv")
             error = get_evaluate_m2_not_found_exception(
                 str(e),
                 self.kwargs["event_id"],
                 self.kwargs["evaluator_id"],
-                request.path
+                request.path,
             )
-            logger.error(error['message'])
+            logger.error(error["message"])
             return Response(error, status=status.HTTP_404_NOT_FOUND)
         except ProgrammingError as e:
             # Gracefully handle when the materialized view doesn't exist as a 503.
@@ -313,7 +325,7 @@ class EvaluatorResultsView(generics.ListAPIView):
         event_id = self.kwargs["event_id"]
         event = Metro2Event.objects.get(id=event_id)
         if not has_permissions_for_request(request, event):
-            return HttpResponse('Unauthorized', status=401)
+            return HttpResponse("Unauthorized", status=401)
 
         # Default to sample view
         view_param = self.request.query_params.get("view", "sample")
@@ -351,21 +363,18 @@ class AccountsListView(generics.ListAPIView):
         return Metro2Event.objects.get(id=event_id)
 
     def get_queryset(self):
-        return self.event.get_all_account_activity(
-        ).with_inconsistency_counts(
-            self.event
-        ).with_months_of_data(
-            self.event
+        return (
+            self.event.get_all_account_activity()
+            .with_hit_count(self.event)
+            .with_record_count(self.event)
         )
 
     def list(self, request, *args, **kwargs):
         # TODO: replace using DRF permissions/check_permissions()
         if not has_permissions_for_request(request, self.event):
-            return HttpResponse('Unauthorized', status=401)
+            return HttpResponse("Unauthorized", status=401)
 
-        queryset = self.filter_queryset(
-            self.get_queryset()
-        ).distinct_accounts()
+        queryset = self.filter_queryset(self.get_queryset()).distinct_accounts()
 
         serializer = AccountListSerializer(queryset, many=True)
         return Response(serializer.data)

--- a/django/evaluate_m2/views.py
+++ b/django/evaluate_m2/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import ProgrammingError
 from django.http import Http404, HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_list_or_404
+from django.utils.functional import cached_property
 
 import botocore
 import django_filters.rest_framework
@@ -344,34 +345,30 @@ class AccountsListView(generics.ListAPIView):
     ]
     filterset_class = AccountListFilterSet
 
-    def get_queryset(self):
+    @cached_property
+    def event(self):
         event_id = self.kwargs["event_id"]
-        event = Metro2Event.objects.get(id=event_id)
+        return Metro2Event.objects.get(id=event_id)
 
-        queryset = event.get_all_account_activity().select_related(
+    def get_queryset(self):
+        return self.event.get_all_account_activity().select_related(
             "k2",
             "k4",
             "l1"
         ).with_inconsistency_counts(
-            event
+            self.event
         ).with_months_of_data(
-            event
+            self.event
         )
 
-        return queryset
-
     def list(self, request, *args, **kwargs):
-        event_id = self.kwargs["event_id"]
-        event = Metro2Event.objects.get(id=event_id)
-
         # TODO: replace using DRF permissions/check_permissions()
-        if not has_permissions_for_request(request, event):
+        if not has_permissions_for_request(request, self.event):
             return HttpResponse('Unauthorized', status=401)
 
         queryset = self.filter_queryset(
             self.get_queryset()
         ).distinct_accounts()
 
-        # Paginate the results
         serializer = AccountListSerializer(queryset, many=True)
         return Response(serializer.data)

--- a/django/evaluate_m2/views.py
+++ b/django/evaluate_m2/views.py
@@ -20,7 +20,7 @@ from evaluate_m2.exception_utils import (
     format_error,
     get_evaluate_m2_not_found_exception,
 )
-from evaluate_m2.filters import EvaluatorResultFilterSet
+from evaluate_m2.filters import AccountListFilterSet, EvaluatorResultFilterSet
 from evaluate_m2.models import (
     EvaluatorMetadata,
     EvaluatorResult,
@@ -338,13 +338,11 @@ class EvaluatorResultsView(generics.ListAPIView):
         return self.get_paginated_response(serializer.data)
 
 
-
-
 class AccountsListView(generics.ListAPIView):
     filter_backends = [
         django_filters.rest_framework.DjangoFilterBackend,
     ]
-    # filterset_class = EvaluatorResultFilterSet
+    filterset_class = AccountListFilterSet
 
     def get_queryset(self):
         event_id = self.kwargs["event_id"]

--- a/django/evaluate_m2/views.py
+++ b/django/evaluate_m2/views.py
@@ -351,10 +351,7 @@ class AccountsListView(generics.ListAPIView):
         return Metro2Event.objects.get(id=event_id)
 
     def get_queryset(self):
-        return self.event.get_all_account_activity().select_related(
-            "k2",
-            "k4",
-            "l1"
+        return self.event.get_all_account_activity(
         ).with_inconsistency_counts(
             self.event
         ).with_months_of_data(

--- a/django/evaluate_m2/views.py
+++ b/django/evaluate_m2/views.py
@@ -29,6 +29,7 @@ from evaluate_m2.models import (
 )
 from evaluate_m2.pagination import EvaluatorResultsPaginator
 from evaluate_m2.serializers import (
+    AccountListSerializer,
     EvaluatorMetadataSerializer,
     EvaluatorResultSerializer,
     EventsViewSerializer,
@@ -335,3 +336,44 @@ class EvaluatorResultsView(generics.ListAPIView):
         page = self.paginate_queryset(queryset)
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
+
+
+
+
+class AccountsListView(generics.ListAPIView):
+    filter_backends = [
+        django_filters.rest_framework.DjangoFilterBackend,
+    ]
+    # filterset_class = EvaluatorResultFilterSet
+
+    def get_queryset(self):
+        event_id = self.kwargs["event_id"]
+        event = Metro2Event.objects.get(id=event_id)
+
+        queryset = event.get_all_account_activity().select_related(
+            "k2",
+            "k4",
+            "l1"
+        ).with_inconsistency_counts(
+            event
+        ).with_months_of_data(
+            event
+        )
+
+        return queryset
+
+    def list(self, request, *args, **kwargs):
+        event_id = self.kwargs["event_id"]
+        event = Metro2Event.objects.get(id=event_id)
+
+        # TODO: replace using DRF permissions/check_permissions()
+        if not has_permissions_for_request(request, event):
+            return HttpResponse('Unauthorized', status=401)
+
+        queryset = self.filter_queryset(
+            self.get_queryset()
+        ).distinct_accounts()
+
+        # Paginate the results
+        serializer = AccountListSerializer(queryset, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
This adds an endpoint to query accounts that are in an event, returning information about accounts within an event. The [API docs](https://github.com/cfpb/Metro2/wiki/API) would look something like this:

### Account list view

`/api/events/{event_id}/accounts/?cons_acct_num={comma separated list of account numbers}`

GET - takes a comma-separated list of account numbers and returns a JSON array of those accounts with their portfolio type, account type, and the total number of evaluator hits and total number of records of data, for a given event.

For example, a query of `/api/events/1/accounts/?cons_acct_num=1234567890,2345678901` should return JSON like:

```json
[
    {
        "cons_acct_num": "1234567890",
        "port_type": "I",
        "acct_type": "00"
        "total_hits": 1,
        "total_records": 5,
    },
    {
        "cons_acct_num": "2345678901",
        "port_type": "I",
        "acct_type": "00"
        "total_hits": 1,
        "total_records": 5,
    },
]
```



## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
