### PR TITLE
GHA tests use postgres instead of SQLite

### DIFF
--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -25,6 +25,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: metro2-data
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     defaults:
       run:
         working-directory: django
@@ -35,5 +50,5 @@ jobs:
         with:
           python-version: 3.13
       - run: python -m pip install --upgrade pip -r ./requirements.txt
-      - run: coverage run ./manage.py test
+      - run: coverage run ./manage.py test --settings=django_application.settings.testing
       - run: coverage report

--- a/django/django_application/settings/testing.py
+++ b/django/django_application/settings/testing.py
@@ -1,0 +1,15 @@
+from .base import *
+
+
+# Database
+# https://docs.djangoproject.com/en/4.2/ref/settings/#databases
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'metro2-data',
+        'USER': 'postgres',
+        'PASSWORD': 'postgres',
+        'HOST': 'localhost',
+        'PORT': '5432'
+    }
+}


### PR DESCRIPTION
## Changes

- In GH Actions, run Django test suite using Postgres database instead of the default SQLite.

## Todos

- Fix the front-end tests so they don't time out waiting for the back-end to be ready. EDIT: I'll work on this in a separate PR
