### PR TITLE
Prevent timeout failures in front-end tests

### DIFF
--- a/.github/workflows/frontend_test.yml
+++ b/.github/workflows/frontend_test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Wait for app to be ready
         run: |
-          npx wait-on http://localhost:8000 --timeout 120000
+          npx wait-on http://localhost:8000 --timeout 180000
 
       - name: Run Cypress
         run: yarn test:e2e:ci


### PR DESCRIPTION
~~Cypress tests seed their own data, so running the `./seed-data.sh` script isn't useful and causes the tests to time out sometimes.~~ Turns out some Cypress tests DO need the seed data, so we do need to run the script. Instead, allow more time for the setup script to run.