### PR TITLE
Simplify evaluator CSV

### DIFF
--- a/django/evaluate_m2/m2_evaluators/eval_metadata.csv
+++ b/django/evaluate_m2/m2_evaluators/eval_metadata.csv
@@ -1,6 +1,2 @@
-id,category,description,long_description,fields_used,fields_display,rationale,potential_harm,alternate_explanation,crrg_reference,
-Portfolio-Type-1,Inconsistencies in account characteristics,"Account type does not match the portfolio type, Line of Credit","Account type does not match the portfolio type, Line of Credit.
-
-Portfolio type: C (Credit)
-Account type≠ 15 (Line of credit), 43 (Debit card), 47 (Credit Line Secured), 89 (Home equity line of credit), 7A (Commercial Line of Credit ), 9B (Business Line Personally Guaranteed)","Portfolio type
-Account type",,,,,,
+id,category,description,long_description,fields_used,fields_display,crrg_reference,potential_harm,rationale,alternate_explanation,interpret_fields_last_modified,additional_notes,additional_notes_last_modified
+Portfolio-Type-1,Inconsistencies in account characteristics,"Account type does not match the portfolio type, Line of Credit","<h4>Account type does not match the portfolio type, Line of Credit. </h4><p>Portfolio type: C (Credit) </p><p>Account type≠ 15 (Line of credit), 43 (Debit card), 47 (Credit Line Secured), 89 (Home equity line of credit), 7A (Commercial Line of Credit ), 9B (Business Line Personally Guaranteed)</p>",port_type;acct_type,,,,,,,,

--- a/django/evaluate_m2/metadata_utils.py
+++ b/django/evaluate_m2/metadata_utils.py
@@ -1,93 +1,83 @@
-# Translate from the plain language field names in the source of
-# truth spreadsheet to code names that match the database columns
-#
-# Any fields that don't appear in the SSOTS are removed.
-code_to_plain_field_map = {
-    # code : plain language
-
+valid_fields = [
     # Account Activity fields
-    "id": "DB record ID",
-    "cons_acct_num": "consumer account number",
-    "activity_date": "activity date",
-    "port_type": "portfolio type",
-    "acct_type": "account type",
-    "date_open": "date open",
-    "credit_limit": "credit limit",
-    "hcola": "highest credit or loan amount",
-    "terms_dur": "terms duration",
-    "terms_freq": "terms frequency",
-    "smpa": "scheduled monthly payment amount",
-    "actual_pmt_amt": "actual payment amount",
-    "acct_stat": "account status",
-    "pmt_rating": "payment rating",
-    "php": "payment history profile",
-    "spc_com_cd": "special comment code",
-    "compl_cond_cd": "compliance condition code",
-    "current_bal": "current balance",
-    "amt_past_due": "amount past due",
-    "orig_chg_off_amt": "original charge-off amount",
-    "doai": "date of account information",
-    "dofd": "date of first delinquency",
-    "date_closed": "date closed",
-    "dolp": "date of last payment",
-    "id_num": "ID number",
+    "id",
+    "cons_acct_num",
+    "activity_date",
+    "port_type",
+    "acct_type",
+    "date_open",
+    "credit_limit",
+    "hcola",
+    "terms_dur",
+    "terms_freq",
+    "smpa",
+    "actual_pmt_amt",
+    "acct_stat",
+    "pmt_rating",
+    "php",
+    "spc_com_cd",
+    "compl_cond_cd",
+    "current_bal",
+    "amt_past_due",
+    "orig_chg_off_amt",
+    "doai",
+    "dofd",
+    "date_closed",
+    "dolp",
+    "id_num",
 
     # Account Holder fields
-    "ecoa": "ecoa",
-    "cons_info_ind": "consumer information indicator",
-    "cons_info_ind_assoc": "consumer information indicators for associated consumers",
-    "ecoa_assoc": "ECOA for associated consumers",
-    "first_name": "first name",
-    "surname": "surname",
+    "ecoa",
+    "cons_info_ind",
+    "cons_info_ind_assoc",
+    "ecoa_assoc",
+    "first_name",
+    "surname",
 
     # K segments
-    "k2__purch_sold_ind": "K2 purchased - sold indicator",
-    "k2__purch_sold_name": "K2 purchased - sold name",
-    "k4__balloon_pmt_amt": "balloon payment amount",
+    "k2__purch_sold_ind",
+    "k2__purch_sold_name",
+    "k4__balloon_pmt_amt",
 
     # L segment
-    "l1__change_ind": "L1 change indicator",
-    "l1__new_acc_num": "L1 new account number",
-    "l1__new_id_num": "L1 new id number",
+    "l1__change_ind",
+    "l1__new_acc_num",
+    "l1__new_id_num",
 
     # Prior record fields
-    "previous_values__cons_info_ind": "prior consumer information indicator",
-    "previous_values__cons_info_ind_assoc": "prior consumer information indicators for associated consumers",  # noqa: E501
-    "previous_values__ecoa": "prior ecoa",
-    "previous_values__first_name": "prior first name",
-    "previous_values__surname": "prior surname",
+    "previous_values__activity_date",
+    "previous_values__port_type",
+    "previous_values__acct_type",
+    "previous_values__date_open",
+    "previous_values__acct_stat",
+    "previous_values__pmt_rating",
+    "previous_values__current_bal",
+    "previous_values__orig_chg_off_amt",
+    "previous_values__dofd",
+    "previous_values__date_closed",
+    "previous_values__id_num",
 
-    "previous_values__l1__change_ind": "prior L1 change indicator",
-    "previous_values__l1__new_acc_num": "prior L1 new account number",
-    "previous_values__l1__new_id_num": "prior L1 new id number",
+    "previous_values__cons_info_ind",
+    "previous_values__cons_info_ind_assoc",
+    "previous_values__ecoa",
+    "previous_values__first_name",
+    "previous_values__surname",
 
-    "previous_values__activity_date": "prior activity date",
-    "previous_values__port_type": "prior portfolio type",
-    "previous_values__acct_type": "prior account type",
-    "previous_values__date_open": "prior date open",
-    "previous_values__acct_stat": "prior account status",
-    "previous_values__pmt_rating": "prior payment rating",
-    "previous_values__current_bal": "prior current balance",
-    "previous_values__orig_chg_off_amt": "prior original charge-off amount",
-    "previous_values__dofd": "prior date of first delinquency",
-    "previous_values__date_closed": "prior date closed",
-    "previous_values__id_num": "prior ID number",
-}
+    "previous_values__l1__change_ind",
+    "previous_values__l1__new_acc_num",
+    "previous_values__l1__new_id_num",
+]
 
-# Invert the dict above to map the other direction
-plain_to_code_field_map = {v.lower(): k for k, v in code_to_plain_field_map.items()}
+def format_fields_for_csv(fields: list) -> str:
+    return ';'.join(fields)
 
-def format_fields_for_csv(fields: list):
-    return '\n'.join(fields)
-
-def parse_fields_from_csv(input: str):
+def parse_fields_from_csv(input: str) -> list[str]:
     """
-    In the source of truth spreadsheet, the 'fields used' and 'fields supplement'
-    columns come in as newline-delimited strings. Parse the lines and return
-    the items.
+    In the source of truth spreadsheet, the 'fields used' and
+    'fields supplement' columns come in as semicolon-delimited
+    strings. Return the list of items.
     """
-    input_list = input.lower().splitlines()
-    # Remove leading and trailing whitespaces in each item in list
-    input_list = [x.strip() for x in input_list]
-    # Filter out blank lines
-    return list(filter(len, input_list))
+    if input.strip():
+        return [val.strip() for val in input.split(";")]
+    else:
+        return []

--- a/django/evaluate_m2/serializers.py
+++ b/django/evaluate_m2/serializers.py
@@ -1,10 +1,9 @@
 from rest_framework import serializers
 
 from evaluate_m2.metadata_utils import (
-    code_to_plain_field_map,
     format_fields_for_csv,
     parse_fields_from_csv,
-    plain_to_code_field_map,
+    valid_fields,
 )
 from evaluate_m2.models import (
     EvaluatorMetadata,
@@ -163,15 +162,9 @@ class EvaluatorMetadataSerializer(serializers.Serializer):
         # First, get the default representation
         json = super().to_representation(instance)
 
-        # Then translate the fields from code to plain language
-        fields_used = [code_to_plain_field_map.get(k, k) for k in json['fields_used']]
-        fields_display = [
-            code_to_plain_field_map.get(k, k) for k in json['fields_display']
-        ]
-
-        # Then override fields_used with the newline-delimited string version
-        json['fields_used'] = format_fields_for_csv(fields_used)
-        json['fields_display'] = format_fields_for_csv(fields_display)
+        # Then override fields_used with semicolon-delimited string
+        json['fields_used'] = format_fields_for_csv(json['fields_used'])
+        json['fields_display'] = format_fields_for_csv(json['fields_display'])
 
         # Also translate default date values to blank
         default_date = str(EvaluatorMetadata._last_modified_never)
@@ -200,15 +193,9 @@ class EvaluatorMetadataSerializer(serializers.Serializer):
         vals = super().to_internal_value(data)
 
         # get the fields_used and fields_display values from the
-        # newline-delimited string columns of the SSoTS
+        # semicolon-delimited string columns of the SSoTS
         vals['fields_used'] = parse_fields_from_csv(vals['fields_used'])
         vals['fields_display'] = parse_fields_from_csv(vals['fields_display'])
-
-        # Then translate the fields from plain language to code
-        vals['fields_used'] = [plain_to_code_field_map.get(k, k) \
-            for k in vals['fields_used']]
-        vals['fields_display'] = [plain_to_code_field_map.get(k, k) \
-            for k in vals['fields_display']]
 
         # signal to the model that this instance is coming from a metadata
         # import, rather than the Admin interface
@@ -223,7 +210,7 @@ class EvaluatorMetadataSerializer(serializers.Serializer):
         """
         invalid_fields = []
         for f in data['fields_used'] + data['fields_display']:
-            if f not in code_to_plain_field_map:
+            if f not in valid_fields:
                 invalid_fields.append(f)
         if invalid_fields:
             raise serializers.ValidationError(f"Invalid field names: {invalid_fields}")

--- a/django/evaluate_m2/tests/test_serializers.py
+++ b/django/evaluate_m2/tests/test_serializers.py
@@ -13,27 +13,6 @@ from evaluate_m2.tests.evaluator_test_helper import acct_record
 from parse_m2.models import M2DataFile, Metro2Event
 
 
-e1_fields_used = """
-consumer information indicator
-date of last payment
-ID number
-"""
-
-e1_fields_display = """
-special comment code
-date of first delinquency
-L1 change indicator
-"""
-
-e2_fields_used = """
-wrong
-misspelled
-"""
-
-e2_fields_display = """
-other
-"""
-
 class EvalSerializerTestCase(TestCase):
     def setUp(self) -> None:
         self.multi_line_text="""Here is some text.
@@ -55,8 +34,8 @@ class EvalSerializerTestCase(TestCase):
             'category': 'paid/not paid',
             'description': 'desc 1',
             'long_description': self.multi_line_text,
-            'fields_used': e1_fields_used.strip(),
-            'fields_display': e1_fields_display.strip(),
+            'fields_used': "cons_info_ind;dolp;id_num",
+            'fields_display': "spc_com_cd;dofd;l1__change_ind",
             'crrg_reference': 'PDF page 3',
             'potential_harm': '',
             'rationale': '',
@@ -83,8 +62,8 @@ class EvalSerializerTestCase(TestCase):
             'category': '',
             'description': '',
             'long_description': '',
-            'fields_used': e2_fields_used.strip(),
-            'fields_display': e2_fields_display.strip(),
+            'fields_used': "wrong;misspelled",
+            'fields_display': "other",
             'crrg_reference': '',
             'potential_harm': '',
             'rationale': '',
@@ -116,51 +95,8 @@ class EvalSerializerTestCase(TestCase):
         self.assertEqual(record.additional_notes_last_modified,
                          EvaluatorMetadata._last_modified_never)
 
-    def test_import_from_json_case_insensitive(self):
-        fields_used = "\r\n".join([
-            "cONsumer information indicator",
-            "date of last payment",
-            "id number",
-        ])
-
-        fields_display = "\r\n".join([
-            "special comment CODE",
-            "date of FIRST delinquency",
-            "L1 change indicator",
-            "ECoa",
-        ])
-
-        eval_json = {
-            'id': 'Test-19',
-            'description': 'desc 1',
-            'long_description': self.multi_line_text,
-            'fields_used': fields_used,
-            'fields_display': fields_display,
-            'crrg_reference': 'PDF page 3',
-            'potential_harm': '',
-            'rationale': '',
-            'alternate_explanation': '',
-            'interpret_fields_last_modified': None,
-            'additional_notes': '',
-            'additional_notes_last_modified': None,
-        }
-
-        from_json = EvaluatorMetadataSerializer(data=eval_json)
-        self.assertTrue(from_json.is_valid())
-        record = from_json.save()
-        self.assertEqual(record.id, "Test-19")
-        self.assertEqual(record.description, self.e1_json['description'])
-        self.assertEqual(record.fields_used, ['cons_info_ind', 'dolp', 'id_num'])
-        self.assertEqual(record.fields_display, ['spc_com_cd', 'dofd', 'l1__change_ind',
-                                                 'ecoa'])
-
     def test_import_fails_when_field_names_incorrect(self):
-        fields = "\r\n".join([
-            "date of last payment",
-            "bogus name",
-            "K2 purchased - sold indicator",
-            "something misspelled",
-        ])
+        fields = "dolp;bogus;k2__purc_sold_ind;wrong"
         e4_json = {
             'id': 'TEST-99',
             'description': '',

--- a/django/evaluate_m2/views.py
+++ b/django/evaluate_m2/views.py
@@ -52,7 +52,8 @@ def download_evaluator_metadata_csv(request):
     )
 
     eval_metadata_serializer = EvaluatorMetadataSerializer(
-        EvaluatorMetadata.objects.all(), many=True
+        EvaluatorMetadata.objects.all().order_by('id'),
+        many=True,
     )
     header = EvaluatorMetadataSerializer.Meta.fields
     # Add the header to the CSV response


### PR DESCRIPTION
Previously, we wanted `eval_metadata.csv` to be human editable when opened in Excel, so we used friendly names for model fields and formatted them as newline-delimited fields. Now that we don't care about human readability of that file, make the format much simpler and easier to produce by using programmatic field names and semicolon delimited lists.

## Testing

1. Back-end tests should pass
2. Docker compose should start up without errors. The output should show the following ("skipped 0" is important):

```
django-1    | Add evaluator Metadata to the database
django-1    | INFO: Read all # rows of the CSV.
django-1    | INFO: Created # and updated # existing evaluators. Skipped 0.
django-1    | INFO: # total evaluators now exist.
```

3. Viewing the evaluator metadata in the django admin should be unchanged from before this PR, including the "fields used" and "fields display" values.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: