### PR TITLE
Improve performance of data import summary page

### DIFF
--- a/django/parse_m2/models.py
+++ b/django/parse_m2/models.py
@@ -61,7 +61,9 @@ class Metro2Event(models.Model):
         for f in files:
             record_ct = next(i for i in record_counts if i['data_file_id']==f['id'])
             f['record_count'] = record_ct['total']
-            unparseable_ct = next(i for i in unparseable_counts if i['data_file_id']==f['id'])
+            unparseable_ct = next(
+                i for i in unparseable_counts if i['data_file_id']==f['id']
+            )
             f['unparseable_data_count'] = unparseable_ct['total']
             file_info.append(f)
 

--- a/django/parse_m2/models.py
+++ b/django/parse_m2/models.py
@@ -67,6 +67,9 @@ class Metro2Event(models.Model):
 
         return file_info
 
+    # used in the Django admin "import data summary" template
+    def get_eval_result_summaries(self):
+        return self.evaluatorresultsummary_set.select_related('evaluator').values()
 
 
     def check_access_for_user(self, user) -> bool:

--- a/django/parse_m2/models.py
+++ b/django/parse_m2/models.py
@@ -39,13 +39,35 @@ class Metro2Event(models.Model):
         call_command('run_evaluators', event_id=self.id)
 
     def total_tradelines(self) -> int:
-        total = 0
-        for file in self.m2datafile_set.all():
-            total += file.accountactivity_set.count()
-        return total
+        return AccountActivity.objects.filter(event_id=self.id).count()
 
-    def get_files_in_order(self):
-        return self.m2datafile_set.order_by('activity_date')
+    # used in the Django admin "import data summary" template
+    def get_file_summary(self):
+        # file info
+        files = self.m2datafile_set.order_by('activity_date').values()
+
+        # data for the "parsed lines" column
+        from django.db.models import Count
+        record_counts = AccountActivity.objects.filter(event_id=self.id) \
+            .values('data_file_id').annotate(total=Count('id'))
+
+        # data for the "unparseable lines" column
+        file_ids = [f['id'] for f in files]
+        unparseable_counts = UnparseableData.objects.filter(data_file_id__in=file_ids) \
+            .values('data_file_id').annotate(total=Count('id'))
+
+        # organize the data into a list of dicts
+        file_info = []
+        for f in files:
+            record_ct = next(i for i in record_counts if i['data_file_id']==f['id'])
+            f['record_count'] = record_ct['total']
+            unparseable_ct = next(i for i in unparseable_counts if i['data_file_id']==f['id'])
+            f['unparseable_data_count'] = unparseable_ct['total']
+            file_info.append(f)
+
+        return file_info
+
+
 
     def check_access_for_user(self, user) -> bool:
         """

--- a/django/templates/admin/parse_m2/event_parse_eval.html
+++ b/django/templates/admin/parse_m2/event_parse_eval.html
@@ -13,7 +13,8 @@
 
 {% block content %}
     <h1>Data import summary for event: {{ object.name }}</h1>
-    {% if object.m2datafile_set.first %}
+    {% with datafile_info=object.get_file_summary %}
+    {% if datafile_info %}
         <h2>Data files imported</h2>
 
         <table style="width: 100%; margin-bottom: 10px;">
@@ -31,13 +32,13 @@
             </tr>
             </thead>
             <tbody>
-            {% for file in object.get_files_in_order %}
+            {% for file in datafile_info %}
                 <tr>
                     <td>{{ file.file_name }}</td>
                     <td>{{ file.activity_date | default_if_none:"-" }}</td>
                     <td>{{ file.parsing_status }}</td>
-                    <td>{{ file.accountactivity_set.count|intcomma }}</td>
-                    <td>{{ file.unparseabledata_set.count|intcomma }}</td>
+                    <td>{{ file.record_count|intcomma }}</td>
+                    <td>{{ file.unparseable_data_count|intcomma }}</td>
                     <td>{{ file.collection | default_if_none:"-" }}</td>
                     <td>{{ file.timestamp|localtime }}</td>
                     <td>{{ file.error_message }}</td>
@@ -47,12 +48,13 @@
             </tbody>
         </table>
 
-        <p><b>Total files imported:</b> {{ object.m2datafile_set.count|intcomma }} </p>
+        <p><b>Total files imported:</b> {{ datafile_info|length|intcomma }} </p>
         <p><b>Total tradelines imported:</b> {{ object.total_tradelines|intcomma }} </p>
 
     {% else %}
         <h3>No data files have been imported for this event</h3>
     {% endif %}
+    {% endwith %}
 
     <h2 style="padding-top: 20px;">Evaluators</h2>
     {% if object.evaluatorresultsummary_set.first %}

--- a/django/templates/admin/parse_m2/event_parse_eval.html
+++ b/django/templates/admin/parse_m2/event_parse_eval.html
@@ -57,7 +57,8 @@
     {% endwith %}
 
     <h2 style="padding-top: 20px;">Evaluators</h2>
-    {% if object.evaluatorresultsummary_set.first %}
+    {% with eval_results=object.evaluatorresultsummary_set %}
+    {% if eval_results.first %}
         <table style="width: 100%; margin-bottom: 10px;">
             <thead>
             <tr>
@@ -69,9 +70,9 @@
             </tr>
             </thead>
             <tbody>
-            {% for result in object.evaluatorresultsummary_set.all %}
+            {% for result in object.get_eval_result_summaries %}
                 <tr>
-                    <td>{{ result.evaluator.id }}</td>
+                    <td>{{ result.evaluator_id }}</td>
                     <td>{{ result.hits|intcomma }}</td>
                     <td>{{ result.inconsistency_start | default_if_none:"-" }}</td>
                     <td>{{ result.inconsistency_end | default_if_none:"-" }}</td>
@@ -81,9 +82,10 @@
             </tbody>
         </table>
 
-        <p><b>Evaluators executed on:</b> {{ object.evaluatorresultsummary_set.first.timestamp }}</p>
+        <p><b>Evaluators executed on:</b> {{ eval_results.first.timestamp }}</p>
     {% else %}
         <h3>No evaluators have been run for this event</h3>
     {% endif %}
+    {% endwith %}
 
 {% endblock %}

--- a/django/templates/admin/parse_m2/event_parse_eval.html
+++ b/django/templates/admin/parse_m2/event_parse_eval.html
@@ -34,19 +34,11 @@
             {% for file in object.get_files_in_order %}
                 <tr>
                     <td>{{ file.file_name }}</td>
-                    {% if file.activity_date %}
-                        <td>{{ file.activity_date }}</td>
-                    {% else %}
-                        <td>-</td>
-                    {% endif %}
+                    <td>{{ file.activity_date | default_if_none:"-" }}</td>
                     <td>{{ file.parsing_status }}</td>
                     <td>{{ file.accountactivity_set.count|intcomma }}</td>
                     <td>{{ file.unparseabledata_set.count|intcomma }}</td>
-                    {% if file.collection %}
-                        <td>{{ file.collection }}</td>
-                    {% else %}
-                        <td>-</td>
-                    {% endif %}
+                    <td>{{ file.collection | default_if_none:"-" }}</td>
                     <td>{{ file.timestamp|localtime }}</td>
                     <td>{{ file.error_message }}</td>
                     <td>{{ file.parser_version }}</td>
@@ -79,16 +71,8 @@
                 <tr>
                     <td>{{ result.evaluator.id }}</td>
                     <td>{{ result.hits|intcomma }}</td>
-                    {% if result.inconsistency_start %}
-                        <td>{{ result.inconsistency_start }}</td>
-                    {% else %}
-                        <td>-</td>
-                    {% endif %}
-                    {% if result.inconsistency_end %}
-                        <td>{{ result.inconsistency_end }}</td>
-                    {% else %}
-                        <td>-</td>
-                    {% endif %}
+                    <td>{{ result.inconsistency_start | default_if_none:"-" }}</td>
+                    <td>{{ result.inconsistency_end | default_if_none:"-" }}</td>
                     <td>{{ result.evaluator_version }}</td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
There was an issue where the data import summary page would time out when attempting to display very large events with lots of files. This PR reduces the number of SQL queries required to load the page, which should make that page more reliable and performant.

## Changes

- Add a model methods to summarize file import info and evaluator result info, to remove that logic from the template
- Use new methods in the Django template to display event summary data
- Streamline code to display table values using `default_if_none` instead of if-else statements

## Testing

1. Using docker compose and the default data in the app, visit http://localhost:8000/admin/parse_m2/metro2event/1/parse_evaluate
2. Django Debut Toolbar should show that the page now loads with 10 SQL queries, compared to 120 queries on `main`.
3. The data and formatting of the page should not change.

## Screenshots

| Before | After |
| --- | --- |
| <img width="228" height="63" alt="Screenshot 2026-08-27 at 11 32 03 AM" src="https://github.com/user-attachments/assets/7b421c69-97c3-4efc-a702-6d9ed5afd69a" /> | <img width="224" height="61" alt="Screenshot 2026-08-27 at 11 36 38 AM" src="https://github.com/user-attachments/assets/9f4bf802-e94a-41ed-b2d7-484a02f5568d" /> |

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
