### PR TITLE
Upgrade python and Django version

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,6 +1,6 @@
 #############################################################################
 ## Stage: base python/django image
-FROM python:3.13-alpine AS base
+FROM python:3.14-alpine AS base
 
 # Ensure that the environment uses UTF-8 encoding by default
 ENV LANG=en_US.UTF-8

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.11.1
 coverage==7.13.5
-Django==5.2.16
+Django==5.2.17
 django-debug-toolbar==7.0.0
 psycopg==3.3.3
 psycopg-binary==3.3.3
@@ -16,9 +16,10 @@ yappi==1.7.6
 django-prose-editor[sanitize]
 
 # Not required directly by Metro2; pinned to avoid CVEs
-certifi==2026.4.22
-cryptography==48.0.1
-idna==3.15
+certifi==2026.7.22
+cryptography==50.0.1
+idna==3.19
 PyJWT==2.13.0
 requests==2.34.2
+sqlparse==0.6.0
 urllib3==2.7.0


### PR DESCRIPTION
Upgrade python to 3.14 and Django to 5.2.17 to resolve security tickets. Addresses internal ticket 1103.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
